### PR TITLE
Initialize CATS project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Node
+node_modules/
+dist/
+
+# .NET
+bin/
+obj/
+
+# Environment
+.env

--- a/backend/CATS.Api.csproj
+++ b/backend/CATS.Api.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello, CATS!");
+
+app.Run();

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,3 @@
+# CATS Backend
+
+ASP.NET Core minimal API targeting .NET 8.

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/database/README.md
+++ b/database/README.md
@@ -1,0 +1,3 @@
+# Database
+
+SQL Server schema and migration scripts will live here.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+Specifications, diagrams, and process flows.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,3 @@
+# CATS Frontend
+
+Vue 3 application scaffolded with Vite, TailwindCSS, and Element Plus.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CATS Frontend</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "cats-frontend",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "vue": "^3.4.0",
+    "vue-pure-admin": "^2.9.0",
+    "element-plus": "^2.7.2",
+    "tailwindcss": "^3.4.4",
+    "pinia": "^2.1.7",
+    "handsontable": "^14.3.0",
+    "ag-grid-vue3": "^31.3.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0",
+    "@vitejs/plugin-vue": "^5.0.0"
+  }
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="p-4">
+    <h1 class="text-2xl font-bold">CATS Frontend</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>
+
+<style scoped>
+</style>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,7 @@
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import App from './App.vue';
+
+const app = createApp(App);
+app.use(createPinia());
+app.mount('#app');

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM"],
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+});

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,3 @@
+# Tests
+
+Unit and integration tests.


### PR DESCRIPTION
## Summary
- scaffold frontend with Vite + Vue 3 configuration
- add minimal ASP.NET Core backend and configuration
- create placeholders for database, docs, and tests with shared .gitignore

## Testing
- `apt-get update` *(fails: repository InRelease is not signed)*
- `dotnet build backend` *(fails: command not found)*
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5742942708320a153bef962a61b2a