### PR TITLE
Add simple login and main dashboard pages

### DIFF
--- a/frontend/login.html
+++ b/frontend/login.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Login</title>
+  <link rel="stylesheet" href="style.css" />
+  <script defer src="login.js"></script>
+</head>
+<body>
+  <div class="login-container">
+    <div class="login-box">
+      <h2>Login</h2>
+      <input type="text" id="username" placeholder="Username" />
+      <input type="password" id="password" placeholder="Password" />
+      <button id="loginBtn">Login</button>
+    </div>
+  </div>
+</body>
+</html>

--- a/frontend/login.js
+++ b/frontend/login.js
@@ -1,0 +1,13 @@
+document.getElementById('loginBtn').addEventListener('click', () => {
+  const username = document.getElementById('username').value.trim();
+  const password = document.getElementById('password').value.trim();
+
+  if (!username || !password) {
+    alert('Please enter username and password');
+    return;
+  }
+
+  // For demo purposes, accept any credentials
+  localStorage.setItem('username', username);
+  window.location.href = 'main.html';
+});

--- a/frontend/main.html
+++ b/frontend/main.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Main Page</title>
+  <link rel="stylesheet" href="style.css" />
+  <script defer src="main.js"></script>
+</head>
+<body>
+  <header>
+    <div class="icon">🐱</div>
+    <div class="user-info" id="userInfo"></div>
+  </header>
+  <div class="main-layout">
+    <nav>
+      <ul>
+        <li>Menu 1</li>
+        <li>Menu 2</li>
+        <li>Menu 3</li>
+      </ul>
+    </nav>
+    <section class="dashboard">
+      <h2>Dashboard</h2>
+      <p>Welcome to the dashboard area.</p>
+    </section>
+  </div>
+</body>
+</html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,0 +1,10 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const username = localStorage.getItem('username');
+  if (!username) {
+    window.location.href = 'login.html';
+    return;
+  }
+
+  const userInfo = document.getElementById('userInfo');
+  userInfo.textContent = `Logged in as: ${username}`;
+});

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,73 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 20px;
+  background-color: #2c3e50;
+  color: #fff;
+}
+
+header .icon {
+  font-size: 24px;
+}
+
+header .user-info {
+  font-size: 16px;
+}
+
+.main-layout {
+  display: flex;
+  height: calc(100vh - 60px);
+}
+
+nav {
+  width: 200px;
+  background-color: #34495e;
+  color: #ecf0f1;
+  padding: 20px;
+}
+
+nav ul {
+  list-style: none;
+  padding: 0;
+}
+
+nav li {
+  margin-bottom: 10px;
+}
+
+.dashboard {
+  flex-grow: 1;
+  padding: 20px;
+  background-color: #ecf0f1;
+}
+
+.login-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+.login-box {
+  padding: 20px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: #fff;
+}
+
+.login-box input {
+  display: block;
+  width: 200px;
+  padding: 8px;
+  margin-bottom: 10px;
+}
+
+.login-box button {
+  padding: 8px 16px;
+}


### PR DESCRIPTION
## Summary
- Implement basic login page that stores username and navigates to main page
- Create main dashboard layout with header icon, user info, left navigation, and right content area
- Add shared CSS styles for login and dashboard layout

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c576310db083208d18be1416845829