### PR TITLE
Use CSV data source before SQL Server

### DIFF
--- a/backend/CATS.Api.csproj
+++ b/backend/CATS.Api.csproj
@@ -4,4 +4,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="../database/sample-data.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -3,4 +3,25 @@ var app = builder.Build();
 
 app.MapGet("/", () => "Hello, CATS!");
 
+app.MapGet("/data", () =>
+{
+    var file = Path.Combine(AppContext.BaseDirectory, "sample-data.csv");
+    if (!File.Exists(file))
+    {
+        return Results.Problem("Data file not found.");
+    }
+
+    var records = File.ReadAllLines(file)
+        .Skip(1)
+        .Select(line =>
+        {
+            var parts = line.Split(',');
+            return new DataRecord(int.Parse(parts[0]), parts[1], parts[2]);
+        });
+
+    return Results.Json(records);
+});
+
 app.Run();
+
+record DataRecord(int Id, string Name, string Value);

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,3 +1,7 @@
 # CATS Backend
 
 ASP.NET Core minimal API targeting .NET 8.
+
+Until the SQL Server database is available, a small CSV file is used as a
+temporary data source. The `/data` endpoint reads from `database/sample-data.csv`
+and returns its content as JSON.

--- a/database/sample-data.csv
+++ b/database/sample-data.csv
@@ -1,0 +1,3 @@
+Id,Name,Value
+1,Electricity,100
+2,Transport,50


### PR DESCRIPTION
## Summary
- add `/data` endpoint that reads a CSV file for temporary data storage
- include sample CSV file and copy configuration
- document temporary CSV data approach

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c584e8c0c88320aefab312c693c231