### PR TITLE
Fix frontend install by dropping unused vue-pure-admin

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "vue": "^3.4.0",
-    "vue-pure-admin": "^2.9.0",
     "element-plus": "^2.7.2",
     "tailwindcss": "^3.4.4",
     "pinia": "^2.1.7",


### PR DESCRIPTION
## Summary
- remove the vue-pure-admin dependency from the frontend package manifest since it is not published to npm and blocks npm install

## Testing
- npm install --no-audit --loglevel=warn --no-progress *(fails in this environment because the proxy returns HTTP 403 for npm registry requests)*

------
https://chatgpt.com/codex/tasks/task_e_68ce268c6c188320b215d955d1adc2f8