### PR TITLE
Add navigable menu pages to dashboard

### DIFF
--- a/frontend/main.html
+++ b/frontend/main.html
@@ -15,15 +15,12 @@
   <div class="main-layout">
     <nav>
       <ul>
-        <li>Menu 1</li>
-        <li>Menu 2</li>
-        <li>Menu 3</li>
+        <li><a class="menu-link" href="temp/menu1.html">Menu 1</a></li>
+        <li><a class="menu-link" href="temp/menu2.html">Menu 2</a></li>
+        <li><a class="menu-link" href="temp/menu3.html">Menu 3</a></li>
       </ul>
     </nav>
-    <section class="dashboard">
-      <h2>Dashboard</h2>
-      <p>Welcome to the dashboard area.</p>
-    </section>
+    <section class="dashboard" id="contentArea"></section>
   </div>
 </body>
 </html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -7,4 +7,42 @@ window.addEventListener('DOMContentLoaded', () => {
 
   const userInfo = document.getElementById('userInfo');
   userInfo.textContent = `Logged in as: ${username}`;
+
+  const contentArea = document.getElementById('contentArea');
+  const menuLinks = document.querySelectorAll('.menu-link');
+
+  const loadPage = (url) => {
+    fetch(url)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load ${url}`);
+        }
+        return response.text();
+      })
+      .then((html) => {
+        contentArea.innerHTML = html;
+      })
+      .catch((error) => {
+        console.error(error);
+        contentArea.innerHTML =
+          '<p class="error-message">Unable to load the requested page.</p>';
+      });
+  };
+
+  menuLinks.forEach((link) => {
+    link.addEventListener('click', (event) => {
+      event.preventDefault();
+      const url = link.getAttribute('href');
+      loadPage(url);
+
+      menuLinks.forEach((menuLink) => menuLink.classList.remove('active'));
+      link.classList.add('active');
+    });
+  });
+
+  if (menuLinks.length > 0) {
+    const firstLink = menuLinks[0];
+    firstLink.classList.add('active');
+    loadPage(firstLink.getAttribute('href'));
+  }
 });

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -41,10 +41,33 @@ nav li {
   margin-bottom: 10px;
 }
 
+nav a {
+  color: #ecf0f1;
+  text-decoration: none;
+  display: block;
+  padding: 8px 12px;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+}
+
+nav a:hover,
+nav a:focus {
+  background-color: #2c3e50;
+}
+
+nav a.active {
+  background-color: #1abc9c;
+  color: #fff;
+}
+
 .dashboard {
   flex-grow: 1;
   padding: 20px;
   background-color: #ecf0f1;
+}
+
+.error-message {
+  color: #c0392b;
 }
 
 .login-container {

--- a/frontend/temp/menu1.html
+++ b/frontend/temp/menu1.html
@@ -1,0 +1,3 @@
+<div class="menu-content">
+  <h2>Menu 1</h2>
+</div>

--- a/frontend/temp/menu2.html
+++ b/frontend/temp/menu2.html
@@ -1,0 +1,3 @@
+<div class="menu-content">
+  <h2>Menu 2</h2>
+</div>

--- a/frontend/temp/menu3.html
+++ b/frontend/temp/menu3.html
@@ -1,0 +1,3 @@
+<div class="menu-content">
+  <h2>Menu 3</h2>
+</div>


### PR DESCRIPTION
## Summary
- convert sidebar menu items into links that load their content dynamically in the dashboard
- add styling and error handling for the sidebar navigation
- create temporary placeholder pages for each menu option

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce35c9549c83209a972ec0015e120f