### PR TITLE
Add menu links and content pages for main dashboard

### DIFF
--- a/frontend/main.html
+++ b/frontend/main.html
@@ -14,10 +14,30 @@
   </header>
   <div class="main-layout">
     <nav>
-      <ul>
-        <li><a class="menu-link" href="temp/menu1.html">Menu 1</a></li>
-        <li><a class="menu-link" href="temp/menu2.html">Menu 2</a></li>
-        <li><a class="menu-link" href="temp/menu3.html">Menu 3</a></li>
+      <ul class="menu">
+        <li class="menu-section" aria-hidden="true"><span>系統參數定義</span></li>
+        <li><a class="menu-link" href="pages/organization-structure.html">組織架構設定</a></li>
+        <li><a class="menu-link" href="pages/emission-source-types.html">排放源類型設定</a></li>
+        <li><a class="menu-link" href="pages/emission-source-site-association.html">排放源與據點關聯管理</a></li>
+        <li><a class="menu-link" href="pages/emission-source-instances.html">排放源實例管理</a></li>
+        <li><a class="menu-link" href="pages/calculation-factors.html">計算因子管理</a></li>
+        <li><a class="menu-link" href="pages/review-process.html">審核流程定義</a></li>
+        <li class="menu-section" aria-hidden="true"><span>資料蒐集</span></li>
+        <li><a class="menu-link" href="pages/stationary-combustion.html">固定燃燒排放源 (發電機)</a></li>
+        <li><a class="menu-link" href="pages/mobile-sources.html">移動排放源 (公務汽車、貨車)</a></li>
+        <li><a class="menu-link" href="pages/fugitive-emissions.html">逸散性排放(飲水機、滅火器、補滅火器)</a></li>
+        <li><a class="menu-link" href="pages/septic-tank.html">化糞池</a></li>
+        <li><a class="menu-link" href="pages/indirect-electricity.html">輸入電力的間接排放 (辦公室用電)</a></li>
+        <li><a class="menu-link" href="pages/upstream-logistics-consumables.html">上游運輸物流經常耗材</a></li>
+        <li><a class="menu-link" href="pages/upstream-office-consumables.html">上游運輸辦公耗材</a></li>
+        <li><a class="menu-link" href="pages/business-travel.html">商務差旅</a></li>
+        <li><a class="menu-link" href="pages/purchased-goods-services-forklift.html">採購商品或服務－倉儲堆高機</a></li>
+        <li><a class="menu-link" href="pages/fuel-energy-related.html">燃料與能源相關活動外購能源</a></li>
+        <li><a class="menu-link" href="pages/logistics-goods-transport.html">物流貨物運輸</a></li>
+        <li><a class="menu-link" href="pages/logistics-transport-land.html">物流運輸排放 (陸運)</a></li>
+        <li><a class="menu-link" href="pages/logistics-transport-sea.html">物流運輸排放 (海運)</a></li>
+        <li><a class="menu-link" href="pages/logistics-transport-air.html">物流運輸排放 (空運)</a></li>
+        <li><a class="menu-link" href="pages/inventory-summary.html">清冊簡表</a></li>
       </ul>
     </nav>
     <section class="dashboard" id="contentArea"></section>

--- a/frontend/pages/business-travel.html
+++ b/frontend/pages/business-travel.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>商務差旅</h1>
+  <p>管理差旅交通與住宿資訊以計算相關排放。</p>
+</section>

--- a/frontend/pages/calculation-factors.html
+++ b/frontend/pages/calculation-factors.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>計算因子管理</h1>
+  <p>維護排放計算所需的係數與相關參數。</p>
+</section>

--- a/frontend/pages/emission-source-instances.html
+++ b/frontend/pages/emission-source-instances.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>排放源實例管理</h1>
+  <p>建立與維護各排放源實際設備或活動的詳細資料。</p>
+</section>

--- a/frontend/pages/emission-source-site-association.html
+++ b/frontend/pages/emission-source-site-association.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>排放源與據點關聯管理</h1>
+  <p>設定各排放源與實際營運據點之間的對應關係。</p>
+</section>

--- a/frontend/pages/emission-source-types.html
+++ b/frontend/pages/emission-source-types.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>排放源類型設定</h1>
+  <p>定義可用的排放源類型以供後續管理與計算使用。</p>
+</section>

--- a/frontend/pages/fuel-energy-related.html
+++ b/frontend/pages/fuel-energy-related.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>燃料與能源相關活動外購能源</h1>
+  <p>記錄外購能源使用情形並計算間接排放。</p>
+</section>

--- a/frontend/pages/fugitive-emissions.html
+++ b/frontend/pages/fugitive-emissions.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>逸散性排放 (飲水機、滅火器、補滅火器)</h1>
+  <p>登錄與追蹤逸散性設備補充與檢修資訊。</p>
+</section>

--- a/frontend/pages/indirect-electricity.html
+++ b/frontend/pages/indirect-electricity.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>輸入電力的間接排放 (辦公室用電)</h1>
+  <p>分析用電數據以估算間接電力排放量。</p>
+</section>

--- a/frontend/pages/inventory-summary.html
+++ b/frontend/pages/inventory-summary.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>清冊簡表</h1>
+  <p>總覽各排放源的關鍵指標與當期排放彙整。</p>
+</section>

--- a/frontend/pages/logistics-goods-transport.html
+++ b/frontend/pages/logistics-goods-transport.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>物流貨物運輸</h1>
+  <p>彙整貨物運輸活動的碳排放與運輸效率指標。</p>
+</section>

--- a/frontend/pages/logistics-transport-air.html
+++ b/frontend/pages/logistics-transport-air.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>物流運輸排放 (空運)</h1>
+  <p>記錄空運作業的托運資料與對應排放量。</p>
+</section>

--- a/frontend/pages/logistics-transport-land.html
+++ b/frontend/pages/logistics-transport-land.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>物流運輸排放 (陸運)</h1>
+  <p>分析陸上運輸方式的燃料耗用與排放表現。</p>
+</section>

--- a/frontend/pages/logistics-transport-sea.html
+++ b/frontend/pages/logistics-transport-sea.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>物流運輸排放 (海運)</h1>
+  <p>追蹤海運運輸的航程、載重與排放因子。</p>
+</section>

--- a/frontend/pages/mobile-sources.html
+++ b/frontend/pages/mobile-sources.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>移動排放源 (公務汽車、貨車)</h1>
+  <p>紀錄車輛行駛與燃料使用資訊以計算移動排放。</p>
+</section>

--- a/frontend/pages/organization-structure.html
+++ b/frontend/pages/organization-structure.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>組織架構設定</h1>
+  <p>管理並維護企業組織架構層級與關聯設定。</p>
+</section>

--- a/frontend/pages/purchased-goods-services-forklift.html
+++ b/frontend/pages/purchased-goods-services-forklift.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>採購商品或服務－倉儲堆高機</h1>
+  <p>掌握倉儲堆高機採購或租賃活動產生的排放。</p>
+</section>

--- a/frontend/pages/review-process.html
+++ b/frontend/pages/review-process.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>審核流程定義</h1>
+  <p>定義資料與報表的審核節點與責任人員。</p>
+</section>

--- a/frontend/pages/septic-tank.html
+++ b/frontend/pages/septic-tank.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>化糞池</h1>
+  <p>管理化糞池操作與抽運紀錄，掌握相關排放資訊。</p>
+</section>

--- a/frontend/pages/stationary-combustion.html
+++ b/frontend/pages/stationary-combustion.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>固定燃燒排放源 (發電機)</h1>
+  <p>彙整並追蹤固定燃燒設備的活動數據與排放量。</p>
+</section>

--- a/frontend/pages/upstream-logistics-consumables.html
+++ b/frontend/pages/upstream-logistics-consumables.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>上游運輸物流經常耗材</h1>
+  <p>記錄物流作業所需耗材的使用量與排放影響。</p>
+</section>

--- a/frontend/pages/upstream-office-consumables.html
+++ b/frontend/pages/upstream-office-consumables.html
@@ -1,0 +1,4 @@
+<section class="page-content">
+  <h1>上游運輸辦公耗材</h1>
+  <p>追蹤辦公相關耗材運輸所造成的碳排放。</p>
+</section>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -94,3 +94,19 @@ nav a.active {
 .login-box button {
   padding: 8px 16px;
 }
+
+.menu-section {
+  margin: 16px 0 8px;
+  font-weight: 700;
+  color: #bdc3c7;
+  text-transform: none;
+}
+
+.menu-section span {
+  display: block;
+  padding: 4px 12px;
+}
+
+nav ul.menu {
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
- populate the main navigation with 21 links covering the required system parameter, data collection, and summary pages
- add lightweight HTML content files for each menu link so the right-hand panel can load dedicated information
- tweak navigation styling to separate section headers from clickable links

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce3e17da808320aeed0437793df015