### PR TITLE
feat: add collapsible navigation and adjust travel table widths

### DIFF
--- a/frontend/pages/business-travel.html
+++ b/frontend/pages/business-travel.html
@@ -10,6 +10,31 @@
 
   <div class="table-wrapper" role="region" aria-labelledby="travelTableCaption">
     <table class="travel-table">
+      <colgroup>
+        <col class="col-company" />
+        <col class="col-site" />
+        <col class="col-activity" />
+        <col class="col-traveler" />
+        <col class="col-date" />
+        <col class="col-date" />
+        <col class="col-transportation" />
+        <col class="col-location" />
+        <col class="col-location" />
+        <col class="col-cabin" />
+        <col class="col-trip" />
+        <col class="col-compact" />
+        <col class="col-distance" />
+        <col class="col-upload" />
+        <col class="col-data-source" />
+        <col class="col-remark" />
+        <col class="col-system" />
+        <col class="col-system" />
+        <col class="col-system" />
+        <col class="col-system" />
+        <col class="col-system" />
+        <col class="col-system" />
+        <col class="col-actions" />
+      </colgroup>
       <caption id="travelTableCaption" class="visually-hidden">商務差旅活動資料輸入表</caption>
       <thead>
         <tr>
@@ -364,10 +389,78 @@
   }
 
   .travel-table {
-    width: max(100%, 1200px);
+    width: max(100%, 1600px);
     border-collapse: collapse;
     font-size: 0.9rem;
-    table-layout: fixed;
+    table-layout: auto;
+  }
+
+  .travel-table col {
+    width: auto;
+  }
+
+  .travel-table .col-company {
+    width: 160px;
+  }
+
+  .travel-table .col-site {
+    width: 150px;
+  }
+
+  .travel-table .col-activity {
+    width: 140px;
+  }
+
+  .travel-table .col-traveler {
+    width: 150px;
+  }
+
+  .travel-table .col-date {
+    width: 130px;
+  }
+
+  .travel-table .col-transportation {
+    width: 150px;
+  }
+
+  .travel-table .col-location {
+    width: 160px;
+  }
+
+  .travel-table .col-cabin {
+    width: 150px;
+  }
+
+  .travel-table .col-trip {
+    width: 120px;
+  }
+
+  .travel-table .col-compact {
+    width: 110px;
+  }
+
+  .travel-table .col-distance {
+    width: 160px;
+  }
+
+  .travel-table .col-upload {
+    width: 170px;
+  }
+
+  .travel-table .col-data-source {
+    width: 160px;
+  }
+
+  .travel-table .col-remark {
+    width: 220px;
+  }
+
+  .travel-table .col-system {
+    width: 150px;
+  }
+
+  .travel-table .col-actions {
+    width: 110px;
   }
 
   .travel-table caption {
@@ -461,7 +554,7 @@
 
   @media (max-width: 1024px) {
     .travel-table {
-      width: max(100%, 980px);
+      width: max(100%, 1200px);
     }
   }
 </style>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -39,7 +39,18 @@
 
     <div v-else class="dashboard-root">
       <header class="top-bar">
-        <div class="logo" aria-hidden="true">🐱</div>
+        <div class="top-bar-left">
+          <button
+            class="toggle-nav-button"
+            type="button"
+            :aria-expanded="!isNavCollapsed"
+            aria-controls="mainNavigation"
+            @click="toggleNavigation"
+          >
+            {{ isNavCollapsed ? '顯示選單' : '隱藏選單' }}
+          </button>
+          <div class="logo" aria-hidden="true">🐱</div>
+        </div>
         <div class="user-info">
           <span class="user-label">Logged in as:</span>
           <span class="user-name">{{ storedUser }}</span>
@@ -47,7 +58,13 @@
         </div>
       </header>
       <main class="main-layout">
-        <nav class="side-nav" aria-label="Main navigation">
+        <nav
+          v-show="!isNavCollapsed"
+          id="mainNavigation"
+          class="side-nav"
+          aria-label="Main navigation"
+          :aria-hidden="isNavCollapsed"
+        >
           <ul class="nav-list">
             <li
               v-for="section in menuSections"
@@ -158,6 +175,7 @@ const menuSections = [
 ];
 
 const isLoggedIn = ref(false);
+const isNavCollapsed = ref(false);
 const errorMessage = ref('');
 
 const form = reactive({
@@ -215,6 +233,7 @@ function handleLogout() {
   localStorage.removeItem(STORAGE_KEYS.username);
   localStorage.removeItem(STORAGE_KEYS.verificationCode);
   form.password = '';
+  isNavCollapsed.value = false;
   isLoggedIn.value = false;
 }
 
@@ -223,6 +242,10 @@ function handleSelectLink(href: string) {
     return;
   }
   setActiveContent(href);
+}
+
+function toggleNavigation() {
+  isNavCollapsed.value = !isNavCollapsed.value;
 }
 
 function loadDefaultContent() {
@@ -352,6 +375,33 @@ if (isLoggedIn.value) {
   background: #1f2937;
   color: #f9fafb;
   box-shadow: 0 4px 12px rgba(15, 23, 42, 0.15);
+}
+
+.top-bar-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.toggle-nav-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: transparent;
+  border: 1px solid rgba(249, 250, 251, 0.4);
+  border-radius: 9999px;
+  color: inherit;
+  padding: 0.4rem 0.85rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.toggle-nav-button:hover,
+.toggle-nav-button:focus {
+  background: rgba(249, 250, 251, 0.12);
+  border-color: rgba(249, 250, 251, 0.6);
+  outline: none;
 }
 
 .logo {
@@ -503,6 +553,15 @@ if (isLoggedIn.value) {
     flex-direction: column;
     gap: 0.75rem;
     text-align: center;
+  }
+
+  .top-bar-left {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .toggle-nav-button {
+    align-self: flex-start;
   }
 
   .main-layout {


### PR DESCRIPTION
## Summary
- add a toggle control that lets users collapse the main navigation and reset when logging out
- hide the menu when collapsed so the dashboard content can stretch to the full width
- define column widths for the business travel entry table to keep every input readable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf926aaa288320992b9a200cc01eb2