### PR TITLE
docs: document Handsontable dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Use any credentials to sign in. The app stores the supplied user ID and
 verification code in `localStorage` and swaps to a dashboard layout with a
 placeholder navigation bar.
 
+> **Handsontable dependency** – Several admin pages now render interactive
+> tables with [Handsontable](https://handsontable.com/). The project loads the
+> library and its styles from the official CDN at runtime, so make sure your
+> development environment has internet access when visiting those pages. No
+> extra installation steps are required beyond `npm install` above.
+
 ---
 
 ## 🧭 Repository structure


### PR DESCRIPTION
## Summary
- update README with guidance about the new Handsontable-powered pages
- clarify that the library loads from the official CDN and requires internet access during development

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daa489b5c08320955cae7457032ba9