### PR TITLE
Preload Handsontable in frontend

### DIFF
--- a/frontend/pages/organization-structure.html
+++ b/frontend/pages/organization-structure.html
@@ -11,11 +11,6 @@
 
 <script>
   (function () {
-    const HANDSONTABLE_STYLE_URL =
-      'https://cdn.jsdelivr.net/npm/handsontable@14.3.0/dist/handsontable.full.min.css';
-    const HANDSONTABLE_SCRIPT_URL =
-      'https://cdn.jsdelivr.net/npm/handsontable@14.3.0/dist/handsontable.full.min.js';
-
     const demoData = [
       { country: '台灣', region: '北部區域', site: '台北總部' },
       { country: '台灣', region: '南部區域', site: '高雄營運中心' },
@@ -78,21 +73,12 @@
       container.__handsontableResizeObserver = resizeObserver;
     }
 
-    function ensureStylesheet() {
-      if (document.querySelector('link[data-handsontable-stylesheet]')) {
-        return;
-      }
-
-      const stylesheet = document.createElement('link');
-      stylesheet.rel = 'stylesheet';
-      stylesheet.href = HANDSONTABLE_STYLE_URL;
-      stylesheet.dataset.handsontableStylesheet = 'true';
-      document.head.appendChild(stylesheet);
-    }
-
     function initializeTable() {
       const container = document.getElementById('organizationStructureTable');
       if (!container || !window.Handsontable) {
+        if (!window.Handsontable) {
+          console.error('Handsontable 尚未預先載入。');
+        }
         return;
       }
 
@@ -126,34 +112,7 @@
       attachResizeObserver(container);
     }
 
-    function loadHandsontable() {
-      if (window.Handsontable) {
-        initializeTable();
-        return;
-      }
-
-      ensureStylesheet();
-
-      let script = document.querySelector('script[data-handsontable-script]');
-
-      if (!script) {
-        script = document.createElement('script');
-        script.src = HANDSONTABLE_SCRIPT_URL;
-        script.dataset.handsontableScript = 'true';
-        script.addEventListener('load', initializeTable, { once: true });
-        document.head.appendChild(script);
-      } else if (script.dataset.loaded === 'true') {
-        initializeTable();
-      } else {
-        script.addEventListener('load', initializeTable, { once: true });
-      }
-
-      script.addEventListener('load', () => {
-        script.dataset.loaded = 'true';
-      }, { once: true });
-    }
-
-    loadHandsontable();
+    initializeTable();
   })();
 </script>
 

--- a/frontend/pages/site-settings.html
+++ b/frontend/pages/site-settings.html
@@ -21,11 +21,6 @@
 
 <script>
   (function () {
-    const HANDSONTABLE_STYLE_URL =
-      'https://cdn.jsdelivr.net/npm/handsontable@14.3.0/dist/handsontable.full.min.css';
-    const HANDSONTABLE_SCRIPT_URL =
-      'https://cdn.jsdelivr.net/npm/handsontable@14.3.0/dist/handsontable.full.min.js';
-
     const siteOptions = [
       { id: 'taipei-hq', name: '台北總部' },
       { id: 'kaohsiung-ops', name: '高雄營運中心' },
@@ -47,18 +42,6 @@
 
     let currentSiteId = siteOptions[0]?.id ?? '';
     let hotInstance = null;
-
-    function ensureStylesheet() {
-      if (document.querySelector('link[data-handsontable-stylesheet]')) {
-        return;
-      }
-
-      const stylesheet = document.createElement('link');
-      stylesheet.rel = 'stylesheet';
-      stylesheet.href = HANDSONTABLE_STYLE_URL;
-      stylesheet.dataset.handsontableStylesheet = 'true';
-      document.head.appendChild(stylesheet);
-    }
 
     function getSiteData(siteId) {
       if (!siteLocationData[siteId]) {
@@ -122,32 +105,12 @@
     }
 
     function initializeTable(siteId) {
-      if (window.Handsontable) {
-        renderTable(siteId);
+      if (!window.Handsontable) {
+        console.error('Handsontable 尚未預先載入。');
         return;
       }
 
-      ensureStylesheet();
-
-      let script = document.querySelector('script[data-handsontable-script]');
-
-      if (!script) {
-        script = document.createElement('script');
-        script.src = HANDSONTABLE_SCRIPT_URL;
-        script.dataset.handsontableScript = 'true';
-        script.addEventListener('load', () => {
-          script.dataset.loaded = 'true';
-          renderTable(siteId);
-        }, { once: true });
-        document.head.appendChild(script);
-      } else if (script.dataset.loaded === 'true') {
-        renderTable(siteId);
-      } else {
-        script.addEventListener('load', () => {
-          script.dataset.loaded = 'true';
-          renderTable(siteId);
-        }, { once: true });
-      }
+      renderTable(siteId);
     }
 
     function handleSiteChange(event) {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,16 @@
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
+import Handsontable from 'handsontable';
+import 'handsontable/dist/handsontable.full.css';
 import App from './App.vue';
+
+declare global {
+  interface Window {
+    Handsontable: typeof Handsontable;
+  }
+}
+
+window.Handsontable = Handsontable;
 
 const app = createApp(App);
 app.use(createPinia());


### PR DESCRIPTION
## Summary
- import Handsontable and its styles in the Vue entrypoint so the library is available without runtime CDN loading
- simplify the organization structure and site settings page scripts to rely on the preloaded Handsontable instance and remove dynamic asset injection

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dab0a3c6608320b2c72df65a756df2