### PR TITLE
Add emission source type Handsontable page

### DIFF
--- a/frontend/pages/emission-source-types.html
+++ b/frontend/pages/emission-source-types.html
@@ -1,4 +1,133 @@
-<section class="page-content">
-  <h1>排放源類型設定</h1>
-  <p>定義可用的排放源類型以供後續管理與計算使用。</p>
+<section class="page-content emission-source-types" aria-labelledby="emissionSourceTypesTitle">
+  <header class="page-header">
+    <h1 id="emissionSourceTypesTitle">排放源類型設定</h1>
+    <p>維護各類排放源類別與名稱，供後續排放源建立與排放量計算時使用。</p>
+  </header>
+
+  <article class="table-card" aria-label="排放源類型清單">
+    <p class="table-description">以下為目前定義的排放源類型，可於表格內直接新增或編輯資料。</p>
+    <div id="emissionSourceTypesTable" class="hot-container" role="application"></div>
+  </article>
 </section>
+
+<script>
+  (function () {
+    const containerId = 'emissionSourceTypesTable';
+    const emissionSourceTypes = [
+      { code: '1.1', name: '固定燃燒排放源 (發電機)' },
+      { code: '1.2', name: '移動排放源 (公務汽車、貨車)' },
+      { code: '1.4', name: '逸散性排放(飲水機、滅火器、補滅火器)' },
+      { code: '1.4', name: '化糞池' },
+      { code: '2.1', name: '輸入電力的間接排放 (辦公室用電)' },
+      { code: '3.1', name: '上游運輸物流經常耗材' },
+      { code: '3.1', name: '上游運輸辦公耗材' },
+      { code: '3.3', name: '物流運輸排放 (陸運)' },
+      { code: '3.3', name: '物流運輸排放 (海運)' },
+      { code: '3.3', name: '物流運輸排放 (空運)' },
+      { code: '3.5', name: '商務差旅' },
+      { code: '4.1', name: '採購商品或服務_倉儲堆高機' },
+      { code: '4.3', name: '燃料與能源相關活動外購能源' }
+    ];
+
+    function initializeTable() {
+      const container = document.getElementById(containerId);
+      if (!container || !window.Handsontable) {
+        console.error('Handsontable 尚未預先載入或找不到目標容器。');
+        return;
+      }
+
+      const existingInstance = container.__handsontableInstance;
+      if (existingInstance) {
+        existingInstance.loadData(emissionSourceTypes);
+        return;
+      }
+
+      const hot = new window.Handsontable(container, {
+        data: emissionSourceTypes,
+        dataSchema: { code: '', name: '' },
+        colHeaders: ['編號', '排放源名稱'],
+        columns: [
+          {
+            data: 'code',
+            type: 'text',
+            placeholder: '輸入編號',
+            validator(value, callback) {
+              callback(!value || value.trim().length > 0);
+            }
+          },
+          {
+            data: 'name',
+            type: 'text',
+            placeholder: '輸入排放源名稱',
+            validator(value, callback) {
+              callback(!value || value.trim().length > 0);
+            }
+          }
+        ],
+        rowHeaders: true,
+        stretchH: 'all',
+        height: 'auto',
+        manualColumnResize: true,
+        manualRowResize: true,
+        licenseKey: 'non-commercial-and-evaluation',
+        className: 'htMiddle',
+        minSpareRows: 1
+      });
+
+      container.__handsontableInstance = hot;
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', initializeTable, { once: true });
+    } else {
+      initializeTable();
+    }
+  })();
+</script>
+
+<style>
+  .emission-source-types {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .emission-source-types .page-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .emission-source-types .page-header h1 {
+    margin: 0;
+    font-size: 2rem;
+    color: #111827;
+  }
+
+  .emission-source-types .page-header p {
+    margin: 0;
+    color: #4b5563;
+    line-height: 1.6;
+  }
+
+  .emission-source-types .table-card {
+    background-color: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .emission-source-types .table-description {
+    margin: 0;
+    color: #4b5563;
+    line-height: 1.5;
+  }
+
+  .emission-source-types .hot-container {
+    width: 100%;
+    min-height: 320px;
+  }
+</style>


### PR DESCRIPTION
## Summary
- build a Handsontable-driven interface on the emission source type settings page
- pre-populate the grid with the provided emission source categories and keep it editable for future additions

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68db7d49652483209ab64138145a8b7b