### PR TITLE
feat: add emission source-site association management

### DIFF
--- a/frontend/pages/emission-source-site-association.html
+++ b/frontend/pages/emission-source-site-association.html
@@ -1,4 +1,275 @@
-<section class="page-content">
-  <h1>排放源與據點關聯管理</h1>
-  <p>設定各排放源與實際營運據點之間的對應關係。</p>
+<section class="page-content emission-source-association" aria-labelledby="emissionSourceAssociationTitle">
+  <header class="page-header">
+    <h1 id="emissionSourceAssociationTitle">排放源與據點關聯管理</h1>
+    <p>
+      針對特定盤查年度與據點挑選適用的排放源，並建立關聯設定供後續排放量盤點作業使用。
+    </p>
+  </header>
+
+  <article class="filter-card" aria-label="條件篩選">
+    <form id="siteAssociationFilters" class="filter-form">
+      <div class="filter-grid">
+        <label class="filter-field" for="inventoryYearSelect">
+          <span class="field-label">盤查年度</span>
+          <select id="inventoryYearSelect" name="inventoryYear" required>
+            <option value="">請選擇盤查年度</option>
+          </select>
+        </label>
+        <label class="filter-field" for="countrySelect">
+          <span class="field-label">國家</span>
+          <select id="countrySelect" name="country" required>
+            <option value="">請選擇國家</option>
+          </select>
+        </label>
+        <label class="filter-field" for="regionSelect">
+          <span class="field-label">區域</span>
+          <select id="regionSelect" name="region" required disabled>
+            <option value="">請先選擇國家</option>
+          </select>
+        </label>
+        <label class="filter-field" for="siteSelect">
+          <span class="field-label">站點</span>
+          <select id="siteSelect" name="site" required disabled>
+            <option value="">請先選擇區域</option>
+          </select>
+        </label>
+      </div>
+      <div class="filter-actions">
+        <p id="filterErrorMessage" class="filter-error" role="alert" aria-live="assertive"></p>
+        <button type="submit" class="primary-action">確認</button>
+      </div>
+    </form>
+  </article>
+
+  <article
+    id="associationResultCard"
+    class="result-card is-inactive"
+    aria-labelledby="emissionSourceListTitle"
+    aria-live="polite"
+  >
+    <header class="result-header">
+      <div>
+        <h2 id="emissionSourceListTitle">可關聯的排放源</h2>
+        <p id="selectionSummary" class="selection-summary">
+          請先設定並確認條件以載入可關聯的排放源。
+        </p>
+      </div>
+    </header>
+
+    <div id="emissionSourceList" class="emission-source-list" role="group" aria-labelledby="emissionSourceListTitle"></div>
+
+    <footer class="result-actions">
+      <button type="button" id="saveAssociationButton" class="primary-action" disabled>儲存設定</button>
+      <p id="saveStatusMessage" class="status-message" role="status" aria-live="polite"></p>
+    </footer>
+  </article>
 </section>
+
+<style>
+  .emission-source-association {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    color: #1f2937;
+  }
+
+  .emission-source-association .page-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .emission-source-association .page-header h1 {
+    margin: 0;
+    font-size: 2rem;
+    color: #111827;
+  }
+
+  .emission-source-association .page-header p {
+    margin: 0;
+    color: #4b5563;
+    line-height: 1.6;
+  }
+
+  .filter-card,
+  .result-card {
+    background-color: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  .filter-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  .filter-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+  }
+
+  .filter-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .field-label {
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: #374151;
+  }
+
+  select {
+    appearance: none;
+    width: 100%;
+    padding: 0.55rem 0.75rem;
+    border-radius: 8px;
+    border: 1px solid #d1d5db;
+    background-color: #ffffff;
+    font-size: 1rem;
+    color: #1f2937;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  select:focus {
+    outline: none;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  }
+
+  .filter-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .filter-error {
+    margin: 0;
+    color: #dc2626;
+    min-height: 1.25rem;
+    flex: 1;
+  }
+
+  .primary-action {
+    align-self: flex-end;
+    background: linear-gradient(135deg, #2563eb, #1d4ed8);
+    color: #ffffff;
+    border: none;
+    border-radius: 10px;
+    padding: 0.65rem 1.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .primary-action:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+    box-shadow: none;
+  }
+
+  .primary-action:not(:disabled):hover {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 20px rgba(29, 78, 216, 0.2);
+  }
+
+  .result-card.is-inactive {
+    display: none;
+  }
+
+  .result-header h2 {
+    margin: 0;
+    font-size: 1.4rem;
+    color: #111827;
+  }
+
+  .selection-summary {
+    margin: 0.35rem 0 0;
+    color: #4b5563;
+  }
+
+  .emission-source-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .emission-source-list:empty::before {
+    content: '目前沒有可用的排放源，請先於排放源類型設定中建立資料。';
+    color: #6b7280;
+  }
+
+  .source-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.85rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 10px;
+    padding: 0.75rem 1rem;
+    background-color: #f9fafb;
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+  }
+
+  .source-row input[type='checkbox'] {
+    margin-top: 0.2rem;
+  }
+
+  .source-row:hover {
+    border-color: #c7d2fe;
+    background-color: #eef2ff;
+  }
+
+  .source-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .source-name {
+    font-weight: 600;
+    color: #1f2937;
+  }
+
+  .source-meta {
+    font-size: 0.9rem;
+    color: #6b7280;
+  }
+
+  .result-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 0.75rem;
+  }
+
+  .status-message {
+    margin: 0;
+    color: #2563eb;
+  }
+
+  @media (max-width: 640px) {
+    .primary-action {
+      width: 100%;
+    }
+
+    .filter-actions {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .filter-error {
+      text-align: left;
+    }
+  }
+</style>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -210,6 +210,13 @@ import('./page-inits/emission-source-types')
         m.initEmissionSourceTypes)
   )
   .catch(() => {});
+import('./page-inits/emission-source-site-association')
+  .then(
+    (m) =>
+      (pageInitializers['pages/emission-source-site-association.html'] =
+        m.initEmissionSourceSiteAssociation)
+  )
+  .catch(() => {});
 
 const activeHref = ref('');
 const activeContent = ref('');

--- a/frontend/src/page-inits/emission-source-site-association.ts
+++ b/frontend/src/page-inits/emission-source-site-association.ts
@@ -1,0 +1,304 @@
+const INVENTORY_YEARS = ['2023', '2024', '2025'];
+
+const SITE_HIERARCHY = [
+  {
+    country: '台灣',
+    regions: [
+      { name: '北部區域', sites: ['台北總部', '松山辦公室'] },
+      { name: '中部區域', sites: ['台中營運處'] },
+      { name: '南部區域', sites: ['高雄營運中心'] },
+    ],
+  },
+  {
+    country: '日本',
+    regions: [{ name: '關東區域', sites: ['東京辦公室'] }],
+  },
+];
+
+const EMISSION_SOURCES = [
+  { id: '1.1', name: '固定燃燒排放源 (發電機)' },
+  { id: '1.2', name: '移動排放源 (公務汽車、貨車)' },
+  { id: '1.4A', name: '逸散性排放 (飲水機)' },
+  { id: '1.4B', name: '逸散性排放 (滅火器)' },
+  { id: '1.4C', name: '逸散性排放 (補滅火器)' },
+  { id: '1.5', name: '化糞池' },
+  { id: '2.1', name: '輸入電力的間接排放 (辦公室用電)' },
+  { id: '3.1A', name: '上游運輸物流經常耗材' },
+  { id: '3.1B', name: '上游運輸辦公耗材' },
+  { id: '3.3L', name: '物流運輸排放 (陸運)' },
+  { id: '3.3S', name: '物流運輸排放 (海運)' },
+  { id: '3.3A', name: '物流運輸排放 (空運)' },
+  { id: '3.5', name: '商務差旅' },
+  { id: '4.1', name: '採購商品或服務－倉儲堆高機' },
+  { id: '4.3', name: '燃料與能源相關活動外購能源' },
+];
+
+type AssociationStore = Record<string, { sources: string[]; updatedAt: string }>;
+
+type Option = { value: string; label: string };
+
+type Selection = {
+  year: string;
+  country: string;
+  region: string;
+  site: string;
+};
+
+function getAssociationStore(): AssociationStore {
+  const globalWindow = window as typeof window & {
+    __emissionSourceSiteAssociations?: AssociationStore;
+  };
+
+  if (!globalWindow.__emissionSourceSiteAssociations) {
+    globalWindow.__emissionSourceSiteAssociations = {};
+  }
+
+  return globalWindow.__emissionSourceSiteAssociations;
+}
+
+function populateSelect(select: HTMLSelectElement, options: Option[], placeholder: string) {
+  const currentValue = select.value;
+  select.innerHTML = '';
+
+  const placeholderOption = document.createElement('option');
+  placeholderOption.value = '';
+  placeholderOption.textContent = placeholder;
+  select.appendChild(placeholderOption);
+
+  options.forEach((option) => {
+    const optionEl = document.createElement('option');
+    optionEl.value = option.value;
+    optionEl.textContent = option.label;
+    select.appendChild(optionEl);
+  });
+
+  if (options.some((option) => option.value === currentValue)) {
+    select.value = currentValue;
+  } else {
+    select.value = '';
+  }
+
+  select.disabled = options.length === 0;
+}
+
+export function initEmissionSourceSiteAssociation() {
+  const form = document.getElementById('siteAssociationFilters') as HTMLFormElement | null;
+  const yearSelect = document.getElementById('inventoryYearSelect') as HTMLSelectElement | null;
+  const countrySelect = document.getElementById('countrySelect') as HTMLSelectElement | null;
+  const regionSelect = document.getElementById('regionSelect') as HTMLSelectElement | null;
+  const siteSelect = document.getElementById('siteSelect') as HTMLSelectElement | null;
+  const errorMessage = document.getElementById('filterErrorMessage');
+  const resultCard = document.getElementById('associationResultCard');
+  const summaryEl = document.getElementById('selectionSummary');
+  const listContainer = document.getElementById('emissionSourceList');
+  const saveButton = document.getElementById('saveAssociationButton') as HTMLButtonElement | null;
+  const statusMessage = document.getElementById('saveStatusMessage');
+
+  if (
+    !form ||
+    !yearSelect ||
+    !countrySelect ||
+    !regionSelect ||
+    !siteSelect ||
+    !resultCard ||
+    !summaryEl ||
+    !listContainer ||
+    !saveButton ||
+    !statusMessage
+  ) {
+    return;
+  }
+
+  populateSelect(
+    yearSelect,
+    INVENTORY_YEARS.map((year) => ({ value: year, label: `${year} 年` })),
+    '請選擇盤查年度'
+  );
+
+  populateSelect(
+    countrySelect,
+    SITE_HIERARCHY.map((item) => ({ value: item.country, label: item.country })),
+    '請選擇國家'
+  );
+
+  const store = getAssociationStore();
+  let currentKey = '';
+  let currentSelection = new Set<string>();
+  let clearStatusTimeout: number | undefined;
+
+  function resetResultCard(message: string) {
+    resultCard.classList.add('is-inactive');
+    listContainer.innerHTML = '';
+    saveButton.disabled = true;
+    summaryEl.textContent = message;
+  }
+
+  function setError(message: string) {
+    if (errorMessage) {
+      errorMessage.textContent = message;
+    }
+  }
+
+  function clearError() {
+    if (errorMessage) {
+      errorMessage.textContent = '';
+    }
+  }
+
+  function clearStatus() {
+    if (clearStatusTimeout) {
+      window.clearTimeout(clearStatusTimeout);
+      clearStatusTimeout = undefined;
+    }
+    statusMessage.textContent = '';
+  }
+
+  function updateRegions() {
+    const country = countrySelect.value;
+    const countryConfig = SITE_HIERARCHY.find((item) => item.country === country);
+    const options = countryConfig
+      ? countryConfig.regions.map((region) => ({ value: region.name, label: region.name }))
+      : [];
+    populateSelect(regionSelect, options, country ? '請選擇區域' : '請先選擇國家');
+
+    if (!country) {
+      populateSelect(siteSelect, [], '請先選擇區域');
+    }
+  }
+
+  function updateSites() {
+    const country = countrySelect.value;
+    const region = regionSelect.value;
+    const countryConfig = SITE_HIERARCHY.find((item) => item.country === country);
+    const regionConfig = countryConfig?.regions.find((item) => item.name === region);
+    const options = regionConfig
+      ? regionConfig.sites.map((site) => ({ value: site, label: site }))
+      : [];
+    populateSelect(siteSelect, options, region ? '請選擇站點' : '請先選擇區域');
+  }
+
+  function formatSelectionSummary(selection: Selection) {
+    return `盤查年度 ${selection.year} · ${selection.country} / ${selection.region} / ${selection.site}`;
+  }
+
+  function renderSourceList(selection: Selection) {
+    listContainer.innerHTML = '';
+
+    EMISSION_SOURCES.forEach((source) => {
+      const wrapper = document.createElement('label');
+      wrapper.className = 'source-row';
+
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.value = source.id;
+      checkbox.checked = currentSelection.has(source.id);
+      checkbox.addEventListener('change', () => {
+        if (checkbox.checked) {
+          currentSelection.add(source.id);
+        } else {
+          currentSelection.delete(source.id);
+        }
+      });
+
+      const info = document.createElement('div');
+      info.className = 'source-info';
+
+      const name = document.createElement('span');
+      name.className = 'source-name';
+      name.textContent = source.name;
+
+      const meta = document.createElement('span');
+      meta.className = 'source-meta';
+      meta.textContent = `類型代碼：${source.id}`;
+
+      info.appendChild(name);
+      info.appendChild(meta);
+      wrapper.appendChild(checkbox);
+      wrapper.appendChild(info);
+      listContainer.appendChild(wrapper);
+    });
+
+    if (!listContainer.children.length) {
+      const emptyMessage = document.createElement('p');
+      emptyMessage.textContent = '目前沒有可供關聯的排放源。';
+      emptyMessage.className = 'source-meta';
+      listContainer.appendChild(emptyMessage);
+    }
+
+    summaryEl.textContent = formatSelectionSummary(selection);
+    resultCard.classList.remove('is-inactive');
+    saveButton.disabled = false;
+  }
+
+  function handleConfirm(event: Event) {
+    event.preventDefault();
+    clearStatus();
+
+    const selection: Selection = {
+      year: yearSelect.value,
+      country: countrySelect.value,
+      region: regionSelect.value,
+      site: siteSelect.value,
+    };
+
+    if (!selection.year) {
+      resetResultCard('請先選擇盤查年度。');
+      setError('請選擇盤查年度。');
+      return;
+    }
+
+    if (!selection.country || !selection.region || !selection.site) {
+      resetResultCard('請完整選擇國家、區域與站點。');
+      setError('請完整選擇國家、區域與站點。');
+      return;
+    }
+
+    clearError();
+
+    currentKey = [selection.year, selection.country, selection.region, selection.site].join('|');
+    const stored = store[currentKey];
+    currentSelection = new Set(stored?.sources ?? []);
+
+    renderSourceList(selection);
+  }
+
+  function handleSave() {
+    if (!currentKey) {
+      setError('請先確認條件後再儲存。');
+      return;
+    }
+
+    clearError();
+
+    const sources = Array.from(currentSelection).sort();
+    store[currentKey] = { sources, updatedAt: new Date().toISOString() };
+
+    const message = sources.length
+      ? `已儲存 ${sources.length} 項排放源關聯。`
+      : '已儲存，目前無勾選排放源。';
+
+    statusMessage.textContent = message;
+
+    clearStatusTimeout = window.setTimeout(() => {
+      if (statusMessage.textContent === message) {
+        statusMessage.textContent = '';
+      }
+      clearStatusTimeout = undefined;
+    }, 4000);
+  }
+
+  updateRegions();
+  updateSites();
+
+  countrySelect.addEventListener('change', () => {
+    updateRegions();
+    updateSites();
+  });
+
+  regionSelect.addEventListener('change', () => {
+    updateSites();
+  });
+
+  form.addEventListener('submit', handleConfirm);
+  saveButton.addEventListener('click', handleSave);
+}


### PR DESCRIPTION
## Summary
- add a dedicated page layout for managing emission source selections per site and inventory year
- implement a page initializer that loads hierarchy options, renders emission sources with checkboxes, and simulates saving selections
- register the new initializer so the dashboard loads the association experience when the page is opened

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db8c777c38832082d299adddac6f66