### PR TITLE
Add upstream logistics consumables data collection UI

### DIFF
--- a/frontend/pages/upstream-logistics-consumables.html
+++ b/frontend/pages/upstream-logistics-consumables.html
@@ -1,4 +1,591 @@
-<section class="page-content">
-  <h1>上游運輸物流經常耗材</h1>
-  <p>記錄物流作業所需耗材的使用量與排放影響。</p>
+<section class="page-content upstream-consumables-page">
+  <header class="page-header">
+    <div class="page-header__text">
+      <h1>上游運輸物流經常耗材</h1>
+      <p>管理物流作業耗材使用與運輸排放資訊，支援審核流程與活動資料維護。</p>
+    </div>
+    <button id="addRecordButton" class="primary-action" type="button">新增活動資料</button>
+  </header>
+
+  <section class="info-card" aria-labelledby="infoCardHeading">
+    <div class="info-card__row">
+      <div class="info-field">
+        <dt id="infoCardHeading">盤查年份</dt>
+        <dd id="inventoryYearDisplay">2024 年</dd>
+      </div>
+      <div class="info-field">
+        <dt>資料審核狀態</dt>
+        <dd>
+          <span id="auditStatusLabel" class="status-badge status-badge--draft" aria-live="polite">草稿</span>
+        </dd>
+      </div>
+      <div class="info-field info-field--actions">
+        <dt class="sr-only">審核操作</dt>
+        <dd>
+          <div id="auditActionButtons" class="button-group" role="group" aria-label="審核操作"></div>
+        </dd>
+      </div>
+    </div>
+    <p id="auditStatusMessage" class="info-card__message" role="status" aria-live="polite"></p>
+  </section>
+
+  <section class="table-card">
+    <div class="table-card__header">
+      <h2>活動資料清單</h2>
+      <p>系統自動依據輸入資料計算重量與排放數值。</p>
+    </div>
+    <div class="table-scroll">
+      <table class="data-table" aria-describedby="inventoryYearDisplay">
+        <thead>
+          <tr>
+            <th scope="col">站點名稱</th>
+            <th scope="col">據點名稱</th>
+            <th scope="col">月份</th>
+            <th scope="col">物流業經常耗材品項</th>
+            <th scope="col">運具</th>
+            <th scope="col">運具用油類型</th>
+            <th scope="col">貨物起點</th>
+            <th scope="col">貨物迄點</th>
+            <th scope="col">品項數量</th>
+            <th scope="col">單品重量 (kg)</th>
+            <th scope="col">貨物總重量 (公噸)</th>
+            <th scope="col">運輸距離 (km)</th>
+            <th scope="col">排放係數 (kg CO₂/延噸公里)</th>
+            <th scope="col">排放量 (kg CO₂e)</th>
+            <th scope="col">活動數據來源</th>
+            <th scope="col">排放係數來源</th>
+          </tr>
+        </thead>
+        <tbody id="consumablesTableBody"></tbody>
+      </table>
+    </div>
+    <p id="emptyTableMessage" class="table-card__empty" hidden>目前尚無活動資料，請新增資料列。</p>
+  </section>
+
+  <section class="page-hint">
+    <h2>填寫說明</h2>
+    <ul>
+      <li>站點名稱由系統依登入帳號自動帶入，使用者無須手動輸入。</li>
+      <li>貨物總重量、排放係數與排放量皆由系統自動計算。</li>
+      <li>品項數量、單品重量與運輸距離欄位僅允許輸入 0 以上之數值。</li>
+    </ul>
+  </section>
+
+  <div id="addRecordModal" class="modal" aria-hidden="true">
+    <div class="modal__overlay" data-close-modal></div>
+    <div class="modal__dialog" role="dialog" aria-modal="true" aria-labelledby="addRecordModalTitle">
+      <header class="modal__header">
+        <h2 id="addRecordModalTitle">新增活動資料</h2>
+        <button class="modal__close" type="button" data-close-modal aria-label="關閉新增視窗"></button>
+      </header>
+      <form id="addRecordForm" class="modal__body">
+        <div class="form-grid">
+          <label class="form-field">
+            <span class="form-label">據點名稱</span>
+            <select name="site" id="modalSiteSelect" required></select>
+          </label>
+          <label class="form-field">
+            <span class="form-label">月份</span>
+            <select name="month" id="modalMonthSelect" required></select>
+          </label>
+          <label class="form-field">
+            <span class="form-label">物流業經常耗材品項</span>
+            <select name="item" id="modalItemSelect" required></select>
+          </label>
+          <label class="form-field">
+            <span class="form-label">運具</span>
+            <select name="vehicle" id="modalVehicleSelect" required></select>
+          </label>
+          <label class="form-field">
+            <span class="form-label">運具用油類型</span>
+            <select name="fuelType" id="modalFuelSelect" required></select>
+          </label>
+          <label class="form-field">
+            <span class="form-label">貨物起點</span>
+            <input name="origin" type="text" required placeholder="例如：台北市" />
+          </label>
+          <label class="form-field">
+            <span class="form-label">貨物迄點</span>
+            <input name="destination" type="text" required placeholder="例如：高雄市" />
+          </label>
+          <label class="form-field">
+            <span class="form-label">品項數量</span>
+            <input name="quantity" type="number" inputmode="decimal" min="0" step="1" required />
+          </label>
+          <label class="form-field">
+            <span class="form-label">單品重量 (kg)</span>
+            <input name="unitWeight" id="unitWeightInput" type="number" inputmode="decimal" min="0" step="0.01" required />
+          </label>
+          <label class="form-field">
+            <span class="form-label">運輸距離 (km)</span>
+            <input name="distance" type="number" inputmode="decimal" min="0" step="0.1" required />
+          </label>
+          <label class="form-field form-field--span">
+            <span class="form-label">活動數據來源</span>
+            <input name="dataSource" type="text" required placeholder="例如：物流系統匯出" />
+          </label>
+          <label class="form-field form-field--span">
+            <span class="form-label">備註 (選填)</span>
+            <textarea name="notes" rows="2" placeholder="可補充計算或資料來源說明"></textarea>
+          </label>
+          <div class="form-field form-field--span">
+            <span class="form-label">活動附件 (選填)</span>
+            <div id="attachmentDropZone" class="drop-zone">
+              <p>拖曳檔案至此或 <button id="browseAttachmentButton" type="button">選擇檔案</button></p>
+              <input id="attachmentInput" name="attachments" type="file" multiple hidden />
+              <ul id="attachmentList" class="attachment-list" aria-live="polite"></ul>
+            </div>
+          </div>
+        </div>
+        <p id="addRecordError" class="form-error" role="alert"></p>
+        <footer class="modal__footer">
+          <button class="secondary-button" type="button" data-close-modal>取消</button>
+          <button class="primary-button" type="submit">儲存</button>
+        </footer>
+      </form>
+    </div>
+  </div>
+
+  <div id="returnReasonModal" class="modal" aria-hidden="true">
+    <div class="modal__overlay" data-close-modal></div>
+    <div class="modal__dialog" role="dialog" aria-modal="true" aria-labelledby="returnReasonModalTitle">
+      <header class="modal__header">
+        <h2 id="returnReasonModalTitle">退回原因</h2>
+        <button class="modal__close" type="button" data-close-modal aria-label="關閉退回視窗"></button>
+      </header>
+      <form id="returnReasonForm" class="modal__body">
+        <label class="form-field form-field--span">
+          <span class="form-label">請輸入退回原因</span>
+          <textarea id="returnReasonInput" name="returnReason" rows="4" required></textarea>
+        </label>
+        <p id="returnReasonError" class="form-error" role="alert"></p>
+        <footer class="modal__footer">
+          <button class="secondary-button" type="button" data-close-modal>取消</button>
+          <button class="primary-button" type="submit">送出</button>
+        </footer>
+      </form>
+    </div>
+  </div>
 </section>
+
+<style>
+.upstream-consumables-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.page-header p {
+  margin: 0.25rem 0 0;
+  color: #4b5563;
+}
+
+.page-header__text {
+  flex: 1;
+}
+
+.primary-action {
+  align-self: flex-start;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  border: none;
+  color: #ffffff;
+  font-weight: 600;
+  padding: 0.65rem 1.5rem;
+  border-radius: 999px;
+  cursor: pointer;
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.2);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(37, 99, 235, 0.25);
+}
+
+.info-card {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.info-card__row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  align-items: center;
+}
+
+.info-field dt {
+  font-size: 0.9rem;
+  color: #6b7280;
+  margin-bottom: 0.25rem;
+}
+
+.info-field dd {
+  margin: 0;
+  font-weight: 600;
+  color: #111827;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.info-field--actions {
+  justify-self: flex-end;
+}
+
+.button-group {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.info-card__message {
+  margin: 0;
+  min-height: 1.25rem;
+  color: #2563eb;
+  font-size: 0.95rem;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.status-badge::before {
+  content: '';
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.status-badge--draft {
+  color: #1f2937;
+  background: #e5e7eb;
+}
+
+.status-badge--submitted {
+  color: #1d4ed8;
+  background: #e0e7ff;
+}
+
+.status-badge--l1 {
+  color: #047857;
+  background: #d1fae5;
+}
+
+.status-badge--l2 {
+  color: #111827;
+  background: linear-gradient(135deg, #fde68a, #fbbf24);
+}
+
+.table-card {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.table-card__header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.table-card__header p {
+  margin: 0.25rem 0 0;
+  color: #6b7280;
+}
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 960px;
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid #e5e7eb;
+  text-align: left;
+  font-size: 0.95rem;
+  white-space: nowrap;
+}
+
+.data-table tbody tr:hover {
+  background: #f9fafb;
+}
+
+.data-table th {
+  background: #f3f4f6;
+  font-weight: 700;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.table-card__empty {
+  margin: 0;
+  color: #6b7280;
+}
+
+.page-hint {
+  background: #f9fafb;
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+}
+
+.page-hint h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+}
+
+.page-hint ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #4b5563;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal.is-active {
+  display: flex;
+}
+
+.modal__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.modal__dialog {
+  position: relative;
+  background: #ffffff;
+  border-radius: 16px;
+  width: min(760px, 95vw);
+  max-height: min(90vh, 960px);
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.25);
+}
+
+.modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.modal__header h2 {
+  margin: 0;
+}
+
+.modal__close {
+  background: transparent;
+  border: none;
+  width: 1.75rem;
+  height: 1.75rem;
+  cursor: pointer;
+  position: relative;
+}
+
+.modal__close::before,
+.modal__close::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 1.2rem;
+  height: 2px;
+  background: #6b7280;
+  transform-origin: center;
+}
+
+.modal__close::before {
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.modal__close::after {
+  transform: translate(-50%, -50%) rotate(-45deg);
+}
+
+.modal__body {
+  padding: 1.25rem 1.5rem 1.5rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem 1.25rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.form-field--span {
+  grid-column: 1 / -1;
+}
+
+.form-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #4b5563;
+}
+
+.form-field input,
+.form-field select,
+.form-field textarea {
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 0.55rem 0.65rem;
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+.form-field input:focus,
+.form-field select:focus,
+.form-field textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+.drop-zone {
+  border: 2px dashed #93c5fd;
+  border-radius: 12px;
+  padding: 1rem;
+  text-align: center;
+  color: #1d4ed8;
+  background: #eff6ff;
+}
+
+.drop-zone.is-dragover {
+  background: #dbeafe;
+  border-color: #1d4ed8;
+}
+
+.drop-zone button {
+  background: none;
+  border: none;
+  color: #1d4ed8;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.attachment-list {
+  margin: 0.5rem 0 0;
+  padding: 0;
+  list-style: none;
+  color: #1f2937;
+  text-align: left;
+}
+
+.attachment-list li {
+  padding: 0.25rem 0;
+}
+
+.form-error {
+  margin: 0;
+  color: #dc2626;
+  min-height: 1rem;
+}
+
+.modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding-top: 0.5rem;
+}
+
+.primary-button,
+.secondary-button {
+  padding: 0.5rem 1.25rem;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.primary-button {
+  border: none;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #ffffff;
+}
+
+.secondary-button {
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  color: #1f2937;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 720px) {
+  .data-table {
+    min-width: 720px;
+  }
+
+  .info-field--actions {
+    justify-self: flex-start;
+  }
+
+  .button-group {
+    justify-content: flex-start;
+  }
+}
+</style>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -217,6 +217,13 @@ import('./page-inits/emission-source-site-association')
         m.initEmissionSourceSiteAssociation)
   )
   .catch(() => {});
+import('./page-inits/upstream-logistics-consumables')
+  .then(
+    (m) =>
+      (pageInitializers['pages/upstream-logistics-consumables.html'] =
+        m.initUpstreamLogisticsConsumables)
+  )
+  .catch(() => {});
 
 const activeHref = ref('');
 const activeContent = ref('');

--- a/frontend/src/page-inits/upstream-logistics-consumables.ts
+++ b/frontend/src/page-inits/upstream-logistics-consumables.ts
@@ -1,0 +1,456 @@
+type AuditStatus = 'Draft' | 'Submitted' | 'L1Approved' | 'L2Approved';
+
+type ConsumableRecord = {
+  location: string;
+  month: number;
+  item: string;
+  vehicle: string;
+  fuelType: string;
+  origin: string;
+  destination: string;
+  quantity: number;
+  unitWeightKg: number;
+  distanceKm: number;
+  dataSource: string;
+  factorSource: string;
+  attachments: string[];
+  notes?: string;
+};
+
+type Option = { value: string | number; label: string };
+
+const INVENTORY_YEAR = '2024';
+const SITE_NAME = '台北物流中心';
+
+const DEPOT_OPTIONS = ['北一倉儲中心', '桃園轉運倉', '高雄配銷點'];
+
+const VEHICLE_OPTIONS = ['3.5T 小貨車', '7.5T 大貨車', '冷鏈貨櫃車'];
+
+const FUEL_OPTIONS = ['92 無鉛汽油', '95 無鉛汽油', '柴油', '航空煤油'];
+
+const CONSUMABLE_ITEMS: { name: string; weightKg: number }[] = [
+  { name: '瓦楞紙箱 (大)', weightKg: 0.85 },
+  { name: '瓦楞紙箱 (中)', weightKg: 0.65 },
+  { name: '填充氣泡袋', weightKg: 0.08 },
+  { name: '棧板', weightKg: 12 },
+  { name: '保冷袋', weightKg: 0.45 },
+];
+
+const EMISSION_FACTORS: Record<string, number> = {
+  '3.5T 小貨車|92 無鉛汽油': 0.168,
+  '3.5T 小貨車|95 無鉛汽油': 0.171,
+  '3.5T 小貨車|柴油': 0.149,
+  '7.5T 大貨車|柴油': 0.131,
+  '冷鏈貨櫃車|柴油': 0.189,
+  '冷鏈貨櫃車|航空煤油': 0.215,
+};
+
+const FACTOR_SOURCE = '交通運輸排放係數資料庫 2024 年版';
+
+const numberFormatter = new Intl.NumberFormat('zh-TW', {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 2,
+});
+
+const weightFormatter = new Intl.NumberFormat('zh-TW', {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 3,
+});
+
+export function initUpstreamLogisticsConsumables() {
+  const statusLabel = document.getElementById('auditStatusLabel');
+  const actionContainer = document.getElementById('auditActionButtons');
+  const messageArea = document.getElementById('auditStatusMessage');
+  const yearDisplay = document.getElementById('inventoryYearDisplay');
+  const tableBody = document.getElementById('consumablesTableBody');
+  const emptyMessage = document.getElementById('emptyTableMessage');
+  const addButton = document.getElementById('addRecordButton');
+  const addModal = document.getElementById('addRecordModal');
+  const addForm = document.getElementById('addRecordForm') as HTMLFormElement | null;
+  const itemSelect = document.getElementById('modalItemSelect') as HTMLSelectElement | null;
+  const unitWeightInput = document.getElementById('unitWeightInput') as HTMLInputElement | null;
+  const monthSelect = document.getElementById('modalMonthSelect') as HTMLSelectElement | null;
+  const siteSelect = document.getElementById('modalSiteSelect') as HTMLSelectElement | null;
+  const vehicleSelect = document.getElementById('modalVehicleSelect') as HTMLSelectElement | null;
+  const fuelSelect = document.getElementById('modalFuelSelect') as HTMLSelectElement | null;
+  const attachmentInput = document.getElementById('attachmentInput') as HTMLInputElement | null;
+  const attachmentList = document.getElementById('attachmentList');
+  const dropZone = document.getElementById('attachmentDropZone');
+  const browseButton = document.getElementById('browseAttachmentButton');
+  const addError = document.getElementById('addRecordError');
+  const reasonModal = document.getElementById('returnReasonModal');
+  const reasonForm = document.getElementById('returnReasonForm') as HTMLFormElement | null;
+  const reasonInput = document.getElementById('returnReasonInput') as HTMLTextAreaElement | null;
+  const reasonError = document.getElementById('returnReasonError');
+
+  if (
+    !statusLabel ||
+    !actionContainer ||
+    !messageArea ||
+    !yearDisplay ||
+    !tableBody ||
+    !emptyMessage ||
+    !addButton ||
+    !addModal ||
+    !addForm ||
+    !itemSelect ||
+    !unitWeightInput ||
+    !monthSelect ||
+    !siteSelect ||
+    !vehicleSelect ||
+    !fuelSelect ||
+    !attachmentInput ||
+    !attachmentList ||
+    !dropZone ||
+    !browseButton ||
+    !addError ||
+    !reasonModal ||
+    !reasonForm ||
+    !reasonInput ||
+    !reasonError
+  ) {
+    return;
+  }
+
+  yearDisplay.textContent = `${INVENTORY_YEAR} 年`;
+
+  const records: ConsumableRecord[] = [
+    {
+      location: DEPOT_OPTIONS[0],
+      month: 3,
+      item: '瓦楞紙箱 (大)',
+      vehicle: '3.5T 小貨車',
+      fuelType: '柴油',
+      origin: '台北市',
+      destination: '台中市',
+      quantity: 320,
+      unitWeightKg: 0.85,
+      distanceKm: 170,
+      dataSource: '物流系統出貨紀錄',
+      factorSource: FACTOR_SOURCE,
+      attachments: ['出貨單據_20240315.pdf'],
+    },
+    {
+      location: DEPOT_OPTIONS[1],
+      month: 4,
+      item: '棧板',
+      vehicle: '7.5T 大貨車',
+      fuelType: '柴油',
+      origin: '桃園市',
+      destination: '高雄市',
+      quantity: 42,
+      unitWeightKg: 12,
+      distanceKm: 330,
+      dataSource: '外包物流運送紀錄',
+      factorSource: FACTOR_SOURCE,
+      attachments: [],
+      notes: '棧板回收循環使用',
+    },
+  ];
+
+  let currentStatus: AuditStatus = 'Draft';
+  let currentAttachments: string[] = [];
+  let statusTimeout: number | undefined;
+
+  populateSelect(
+    monthSelect,
+    Array.from({ length: 12 }, (_, i) => ({ value: i + 1, label: `${i + 1} 月` })),
+    '請選擇月份'
+  );
+
+  populateSelect(siteSelect, DEPOT_OPTIONS.map((label) => ({ value: label, label })), '請選擇據點');
+  populateSelect(vehicleSelect, VEHICLE_OPTIONS.map((label) => ({ value: label, label })), '請選擇運具');
+  populateSelect(fuelSelect, FUEL_OPTIONS.map((label) => ({ value: label, label })), '請選擇燃料');
+  populateSelect(
+    itemSelect,
+    CONSUMABLE_ITEMS.map((item) => ({ value: item.name, label: `${item.name}（${item.weightKg} kg/件）` })),
+    '請選擇耗材品項'
+  );
+
+  itemSelect.addEventListener('change', () => {
+    const selected = CONSUMABLE_ITEMS.find((item) => item.name === itemSelect.value);
+    if (selected && !unitWeightInput.readOnly) {
+      unitWeightInput.value = selected.weightKg.toString();
+    }
+  });
+
+  browseButton.addEventListener('click', () => attachmentInput.click());
+
+  attachmentInput.addEventListener('change', () => {
+    currentAttachments = collectAttachmentNames(attachmentInput.files);
+    renderAttachmentList(attachmentList, currentAttachments);
+  });
+
+  dropZone.addEventListener('dragover', (event) => {
+    event.preventDefault();
+    dropZone.classList.add('is-dragover');
+  });
+
+  dropZone.addEventListener('dragleave', () => {
+    dropZone.classList.remove('is-dragover');
+  });
+
+  dropZone.addEventListener('drop', (event) => {
+    event.preventDefault();
+    dropZone.classList.remove('is-dragover');
+
+    const files = event.dataTransfer?.files;
+    if (files && files.length > 0) {
+      currentAttachments = collectAttachmentNames(files);
+      renderAttachmentList(attachmentList, currentAttachments);
+    }
+  });
+
+  addForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    addError.textContent = '';
+
+    try {
+      const formData = new FormData(addForm);
+      const quantity = getNonNegativeNumber(formData.get('quantity'), '品項數量');
+      const unitWeightKg = getNonNegativeNumber(formData.get('unitWeight'), '單品重量');
+      const distanceKm = getNonNegativeNumber(formData.get('distance'), '運輸距離');
+
+      const record: ConsumableRecord = {
+        location: String(formData.get('site') || ''),
+        month: Number(formData.get('month') || 0),
+        item: String(formData.get('item') || ''),
+        vehicle: String(formData.get('vehicle') || ''),
+        fuelType: String(formData.get('fuelType') || ''),
+        origin: String(formData.get('origin') || ''),
+        destination: String(formData.get('destination') || ''),
+        quantity,
+        unitWeightKg,
+        distanceKm,
+        dataSource: String(formData.get('dataSource') || ''),
+        factorSource: FACTOR_SOURCE,
+        attachments: [...currentAttachments],
+        notes: String(formData.get('notes') || '').trim() || undefined,
+      };
+
+      records.push(record);
+      renderTable();
+      closeModal(addModal);
+      addForm.reset();
+      currentAttachments = [];
+      renderAttachmentList(attachmentList, currentAttachments);
+      unitWeightInput.value = '';
+      showMessage(`${record.item} 已新增至活動資料。`);
+    } catch (error) {
+      addError.textContent = error instanceof Error ? error.message : '欄位驗證失敗，請重新確認。';
+    }
+  });
+
+  addButton.addEventListener('click', () => {
+    addForm.reset();
+    currentAttachments = [];
+    renderAttachmentList(attachmentList, currentAttachments);
+    unitWeightInput.value = '';
+    openModal(addModal);
+    addError.textContent = '';
+    monthSelect.focus();
+  });
+
+  setupModalDismissal(addModal);
+  setupModalDismissal(reasonModal);
+
+  reasonForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    reasonError.textContent = '';
+
+    const reason = reasonInput.value.trim();
+    if (!reason) {
+      reasonError.textContent = '請填寫退回原因後再送出。';
+      return;
+    }
+
+    currentStatus = 'Draft';
+    updateStatusUI();
+    closeModal(reasonModal);
+    reasonInput.value = '';
+    showMessage(`資料已退回。原因：${reason}`);
+  });
+
+  renderTable();
+  updateStatusUI();
+
+  function renderTable() {
+    tableBody.innerHTML = '';
+
+    if (records.length === 0) {
+      emptyMessage.hidden = false;
+      return;
+    }
+
+    emptyMessage.hidden = true;
+
+    records.forEach((record) => {
+      const row = document.createElement('tr');
+      const totalWeight = (record.quantity * record.unitWeightKg) / 1000;
+      const emissionFactor = resolveEmissionFactor(record.vehicle, record.fuelType);
+      const emission = totalWeight * record.distanceKm * emissionFactor;
+
+      appendCell(row, SITE_NAME);
+      appendCell(row, record.location);
+      appendCell(row, `${record.month} 月`);
+      appendCell(row, record.item);
+      appendCell(row, record.vehicle);
+      appendCell(row, record.fuelType);
+      appendCell(row, record.origin);
+      appendCell(row, record.destination);
+      appendCell(row, numberFormatter.format(record.quantity));
+      appendCell(row, numberFormatter.format(record.unitWeightKg));
+      appendCell(row, weightFormatter.format(totalWeight));
+      appendCell(row, numberFormatter.format(record.distanceKm));
+      appendCell(row, weightFormatter.format(emissionFactor));
+      appendCell(row, numberFormatter.format(emission));
+      appendCell(row, record.dataSource);
+      appendCell(row, record.factorSource);
+
+      tableBody.appendChild(row);
+    });
+  }
+
+  function updateStatusUI() {
+    const { label, className } = mapStatusToDisplay(currentStatus);
+    statusLabel.textContent = label;
+    statusLabel.className = `status-badge ${className}`;
+
+    actionContainer.innerHTML = '';
+
+    if (currentStatus === 'Draft') {
+      actionContainer.appendChild(createActionButton('送審', () => {
+        currentStatus = 'Submitted';
+        updateStatusUI();
+        showMessage('資料已送審，等待 L1 審核。');
+      }));
+    } else if (currentStatus === 'Submitted' || currentStatus === 'L1Approved') {
+      actionContainer.appendChild(
+        createActionButton('退回', () => {
+          reasonError.textContent = '';
+          reasonInput.value = '';
+          openModal(reasonModal);
+          reasonInput.focus();
+        }, true)
+      );
+
+      actionContainer.appendChild(
+        createActionButton('審核通過', () => {
+          if (currentStatus === 'Submitted') {
+            currentStatus = 'L1Approved';
+            showMessage('資料已通過 L1 審核，等待 L2 審核。');
+          } else {
+            currentStatus = 'L2Approved';
+            showMessage('資料已完成 L2 審核。');
+          }
+          updateStatusUI();
+        })
+      );
+    }
+  }
+
+  function showMessage(message: string) {
+    messageArea.textContent = message;
+    if (statusTimeout) {
+      window.clearTimeout(statusTimeout);
+    }
+    statusTimeout = window.setTimeout(() => {
+      messageArea.textContent = '';
+    }, 5000);
+  }
+
+  function createActionButton(label: string, onClick: () => void, isSecondary = false) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = isSecondary ? 'secondary-button' : 'primary-button';
+    button.textContent = label;
+    button.addEventListener('click', onClick);
+    return button;
+  }
+
+  function mapStatusToDisplay(status: AuditStatus) {
+    switch (status) {
+      case 'Draft':
+        return { label: '草稿', className: 'status-badge--draft' };
+      case 'Submitted':
+        return { label: '待審 (L1)', className: 'status-badge--submitted' };
+      case 'L1Approved':
+        return { label: 'L1 審核通過', className: 'status-badge--l1' };
+      case 'L2Approved':
+        return { label: 'L2 審核通過', className: 'status-badge--l2' };
+      default:
+        return { label: '草稿', className: 'status-badge--draft' };
+    }
+  }
+
+  function resolveEmissionFactor(vehicle: string, fuel: string) {
+    const key = `${vehicle}|${fuel}`;
+    return EMISSION_FACTORS[key] ?? 0.102;
+  }
+
+  function appendCell(row: HTMLTableRowElement, text: string) {
+    const cell = document.createElement('td');
+    cell.textContent = text;
+    row.appendChild(cell);
+  }
+
+  function populateSelect(select: HTMLSelectElement, options: Option[], placeholder: string) {
+    select.innerHTML = '';
+
+    const placeholderOption = document.createElement('option');
+    placeholderOption.value = '';
+    placeholderOption.textContent = placeholder;
+    placeholderOption.disabled = true;
+    placeholderOption.selected = true;
+    select.appendChild(placeholderOption);
+
+    options.forEach((option) => {
+      const el = document.createElement('option');
+      el.value = String(option.value);
+      el.textContent = option.label;
+      select.appendChild(el);
+    });
+  }
+
+  function getNonNegativeNumber(value: FormDataEntryValue | null, label: string) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric < 0) {
+      throw new Error(`${label} 需輸入 0 以上之數值。`);
+    }
+    return numeric;
+  }
+
+  function collectAttachmentNames(fileList: FileList | null) {
+    if (!fileList) return [];
+    return Array.from(fileList).map((file) => file.name);
+  }
+
+  function renderAttachmentList(list: HTMLElement, attachments: string[]) {
+    list.innerHTML = '';
+    attachments.forEach((name) => {
+      const item = document.createElement('li');
+      item.textContent = name;
+      list.appendChild(item);
+    });
+  }
+
+  function openModal(modal: HTMLElement) {
+    modal.classList.add('is-active');
+    modal.setAttribute('aria-hidden', 'false');
+  }
+
+  function closeModal(modal: HTMLElement) {
+    modal.classList.remove('is-active');
+    modal.setAttribute('aria-hidden', 'true');
+  }
+
+  function setupModalDismissal(modal: HTMLElement) {
+    modal.addEventListener('click', (event) => {
+      const target = event.target as HTMLElement;
+      if (target.matches('[data-close-modal]')) {
+        closeModal(modal);
+      }
+    });
+  }
+}
+


### PR DESCRIPTION
## Summary
- build the upstream logistics consumables page with status banner, activity table, and guidance
- implement page initializer that drives review flow, calculations, and activity creation with attachments
- register the initializer in the SPA so the page loads and behaves correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db91de7a9c832099bb73213eb2e882