### PR TITLE
feat: build stationary combustion activity collection page

### DIFF
--- a/frontend/pages/stationary-combustion.html
+++ b/frontend/pages/stationary-combustion.html
@@ -1,4 +1,570 @@
-<section class="page-content">
-  <h1>固定燃燒排放源 (發電機)</h1>
-  <p>彙整並追蹤固定燃燒設備的活動數據與排放量。</p>
+<section class="page-content stationary-combustion-page">
+  <header class="page-header">
+    <div class="page-header__text">
+      <h1>固定燃燒排放源活動蒐集</h1>
+      <p>管理固定燃燒排放源的活動資料與排放係數，支援審核流程與資料維護。</p>
+    </div>
+    <button id="addCombustionRecordButton" class="primary-action" type="button">新增活動資料</button>
+  </header>
+
+  <section class="info-card" aria-labelledby="stationaryInfoHeading">
+    <div class="info-card__row">
+      <div class="info-field">
+        <dt id="stationaryInfoHeading">盤查年份</dt>
+        <dd id="stationaryInventoryYear">2024 年</dd>
+      </div>
+      <div class="info-field">
+        <dt>資料審核狀態</dt>
+        <dd>
+          <span id="stationaryAuditStatus" class="status-badge status-badge--draft" aria-live="polite">草稿</span>
+        </dd>
+      </div>
+      <div class="info-field info-field--actions">
+        <dt class="sr-only">審核操作</dt>
+        <dd>
+          <div id="stationaryAuditActions" class="button-group" role="group" aria-label="審核操作"></div>
+        </dd>
+      </div>
+    </div>
+    <p id="stationaryAuditMessage" class="info-card__message" role="status" aria-live="polite"></p>
+  </section>
+
+  <section class="table-card">
+    <div class="table-card__header">
+      <h2>活動資料清單</h2>
+      <p>系統依輸入資料與排放係數自動計算溫室氣體排放量。</p>
+    </div>
+    <div class="table-scroll">
+      <table class="data-table" aria-describedby="stationaryInventoryYear">
+        <thead>
+          <tr>
+            <th scope="col" class="col-actions">操作</th>
+            <th scope="col">站點名稱</th>
+            <th scope="col">據點名稱</th>
+            <th scope="col">活動/設備</th>
+            <th scope="col">編號</th>
+            <th scope="col">油品類型</th>
+            <th scope="col">月份</th>
+            <th scope="col">活動數據 (採購量)</th>
+            <th scope="col">活動數據單位</th>
+            <th scope="col">CO₂ 排放係數</th>
+            <th scope="col">CO₂ 排放係數單位</th>
+            <th scope="col">CO₂ GWP</th>
+            <th scope="col">CH₄ 排放係數</th>
+            <th scope="col">CH₄ 排放係數單位</th>
+            <th scope="col">CH₄ GWP</th>
+            <th scope="col">N₂O 排放係數</th>
+            <th scope="col">N₂O 排放係數單位</th>
+            <th scope="col">N₂O GWP</th>
+            <th scope="col">溫室氣體排放量 (kg CO₂e)</th>
+            <th scope="col">活動數據來源</th>
+            <th scope="col">係數來源</th>
+            <th scope="col">備註</th>
+          </tr>
+        </thead>
+        <tbody id="stationaryTableBody"></tbody>
+      </table>
+    </div>
+    <p id="stationaryEmptyMessage" class="table-card__empty" hidden>目前尚無活動資料，請新增資料。</p>
+  </section>
+
+  <section class="page-hint">
+    <h2>填寫說明</h2>
+    <ul>
+      <li>站點名稱與活動設備編號由系統依排放源設定自動帶入。</li>
+      <li>排放係數與 GWP 由計算係數表依條件自動套用，無須手動輸入。</li>
+      <li>活動數據欄位僅允許輸入 0 以上之數值，請確保來源說明完整。</li>
+    </ul>
+  </section>
+
+  <div id="stationaryAddModal" class="modal" aria-hidden="true">
+    <div class="modal__overlay" data-close-modal></div>
+    <div class="modal__dialog" role="dialog" aria-modal="true" aria-labelledby="stationaryAddModalTitle">
+      <header class="modal__header">
+        <h2 id="stationaryAddModalTitle">新增固定燃燒活動資料</h2>
+        <button class="modal__close" type="button" data-close-modal aria-label="關閉新增視窗"></button>
+      </header>
+      <form id="stationaryAddForm" class="modal__body">
+        <div class="form-grid">
+          <label class="form-field">
+            <span class="form-label">據點名稱</span>
+            <select id="stationaryModalDepot" name="depot" required></select>
+          </label>
+          <label class="form-field">
+            <span class="form-label">活動/設備</span>
+            <select id="stationaryModalActivity" name="activity" required></select>
+          </label>
+          <label class="form-field">
+            <span class="form-label">油品類型</span>
+            <select id="stationaryModalFuel" name="fuelType" required></select>
+          </label>
+          <label class="form-field">
+            <span class="form-label">月份</span>
+            <select id="stationaryModalMonth" name="month" required></select>
+          </label>
+          <label class="form-field">
+            <span class="form-label">活動數據 (採購量)</span>
+            <input id="stationaryModalQuantity" name="quantity" type="number" inputmode="decimal" min="0" step="0.01" required />
+          </label>
+          <label class="form-field">
+            <span class="form-label">活動數據單位</span>
+            <select id="stationaryModalUnit" name="unit" required>
+              <option value="公升">公升</option>
+              <option value="加侖">加侖</option>
+            </select>
+          </label>
+          <label class="form-field form-field--span">
+            <span class="form-label">活動數據來源</span>
+            <input id="stationaryModalSource" name="dataSource" type="text" required placeholder="例如：採購系統匯出" />
+          </label>
+          <div class="form-field form-field--span">
+            <span class="form-label">活動附件 (選填)</span>
+            <div id="stationaryModalDropZone" class="drop-zone">
+              <p>拖曳檔案至此或 <button id="stationaryModalBrowse" type="button">選擇檔案</button></p>
+              <input id="stationaryModalAttachments" name="attachments" type="file" multiple hidden />
+              <ul id="stationaryModalAttachmentList" class="attachment-list" aria-live="polite"></ul>
+            </div>
+          </div>
+          <label class="form-field form-field--span">
+            <span class="form-label">備註 (選填)</span>
+            <textarea id="stationaryModalNotes" name="notes" rows="2" placeholder="可補充燃料用途或採購資訊"></textarea>
+          </label>
+        </div>
+        <p id="stationaryModalError" class="form-error" role="alert"></p>
+        <footer class="modal__footer">
+          <button class="secondary-button" type="button" data-close-modal>取消</button>
+          <button class="primary-button" type="submit">儲存</button>
+        </footer>
+      </form>
+    </div>
+  </div>
+
+  <div id="stationaryReturnModal" class="modal" aria-hidden="true">
+    <div class="modal__overlay" data-close-modal></div>
+    <div class="modal__dialog" role="dialog" aria-modal="true" aria-labelledby="stationaryReturnModalTitle">
+      <header class="modal__header">
+        <h2 id="stationaryReturnModalTitle">退回原因</h2>
+        <button class="modal__close" type="button" data-close-modal aria-label="關閉退回視窗"></button>
+      </header>
+      <form id="stationaryReturnForm" class="modal__body">
+        <label class="form-field form-field--span">
+          <span class="form-label">請輸入退回原因</span>
+          <textarea id="stationaryReturnReason" name="returnReason" rows="4" required placeholder="請說明退回原因"></textarea>
+        </label>
+        <p id="stationaryReturnError" class="form-error" role="alert"></p>
+        <footer class="modal__footer">
+          <button class="secondary-button" type="button" data-close-modal>取消</button>
+          <button class="primary-button" type="submit">送出</button>
+        </footer>
+      </form>
+    </div>
+  </div>
 </section>
+
+<style>
+.stationary-combustion-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.page-header p {
+  margin: 0.25rem 0 0;
+  color: #4b5563;
+}
+
+.page-header__text {
+  flex: 1;
+}
+
+.primary-action {
+  align-self: flex-start;
+  padding: 0.65rem 1.25rem;
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 10px 25px rgba(37, 99, 235, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(37, 99, 235, 0.3);
+}
+
+.info-card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.info-card__row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  align-items: center;
+}
+
+.info-field dt {
+  font-size: 0.9rem;
+  color: #6b7280;
+  margin: 0 0 0.25rem;
+}
+
+.info-field dd {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.info-field--actions {
+  justify-self: flex-end;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.status-badge::before {
+  content: '';
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.status-badge--draft {
+  color: #2563eb;
+  background: rgba(37, 99, 235, 0.15);
+}
+
+.status-badge--submitted {
+  color: #f59e0b;
+  background: rgba(245, 158, 11, 0.18);
+}
+
+.status-badge--l1 {
+  color: #10b981;
+  background: rgba(16, 185, 129, 0.16);
+}
+
+.status-badge--l2 {
+  color: #1f2937;
+  background: rgba(31, 41, 55, 0.12);
+}
+
+.button-group {
+  display: inline-flex;
+  gap: 0.5rem;
+}
+
+.secondary-button,
+.primary-button {
+  border-radius: 999px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.5rem 1.25rem;
+  cursor: pointer;
+  border: none;
+}
+
+.secondary-button {
+  background: #e5e7eb;
+  color: #374151;
+}
+
+.secondary-button:hover {
+  background: #d1d5db;
+}
+
+.primary-button {
+  background: #2563eb;
+  color: #fff;
+  box-shadow: 0 8px 18px rgba(37, 99, 235, 0.25);
+}
+
+.primary-button:hover {
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.35);
+}
+
+.table-card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.table-card__header h2 {
+  margin: 0;
+}
+
+.table-card__header p {
+  margin: 0.25rem 0 0;
+  color: #6b7280;
+}
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.data-table thead th {
+  background: #f3f4f6;
+  text-align: left;
+  padding: 0.75rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.data-table tbody td {
+  padding: 0.65rem 0.75rem;
+  border-top: 1px solid #e5e7eb;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.data-table tbody tr:nth-child(even) {
+  background: #f9fafb;
+}
+
+.col-actions {
+  width: 72px;
+}
+
+.editable-cell {
+  background: #fef9c3;
+}
+
+.table-card__empty {
+  text-align: center;
+  color: #6b7280;
+  margin: 0;
+}
+
+.page-hint {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.1);
+  padding: 1.25rem 1.5rem;
+}
+
+.page-hint h2 {
+  margin: 0 0 0.5rem;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal[aria-hidden='false'] {
+  display: flex;
+}
+
+.modal__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.modal__dialog {
+  position: relative;
+  background: #fff;
+  border-radius: 16px;
+  width: min(720px, 96%);
+  max-height: 90vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.2);
+}
+
+.modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.modal__body {
+  padding: 1.25rem 1.5rem;
+  overflow-y: auto;
+}
+
+.modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem 1.25rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.modal__close {
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  position: relative;
+}
+
+.modal__close::before,
+.modal__close::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 16px;
+  height: 2px;
+  background: #6b7280;
+  transform-origin: center;
+}
+
+.modal__close::before {
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.modal__close::after {
+  transform: translate(-50%, -50%) rotate(-45deg);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem 1.25rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.form-field--span {
+  grid-column: 1 / -1;
+}
+
+.form-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #374151;
+}
+
+.form-field input,
+.form-field select,
+.form-field textarea {
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-field input:focus,
+.form-field select:focus,
+.form-field textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+.form-error {
+  color: #dc2626;
+  min-height: 1.25rem;
+  margin: 0.5rem 0 0;
+}
+
+.drop-zone {
+  border: 2px dashed #9ca3af;
+  border-radius: 12px;
+  padding: 1rem;
+  text-align: center;
+  color: #6b7280;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.drop-zone.is-dragover {
+  border-color: #2563eb;
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.drop-zone button {
+  background: none;
+  color: #2563eb;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.attachment-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  color: #4b5563;
+}
+
+.attachment-list li {
+  padding: 0.25rem 0;
+}
+
+@media (max-width: 768px) {
+  .page-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .info-field--actions {
+    justify-self: stretch;
+  }
+
+  .button-group {
+    width: 100%;
+  }
+
+  .button-group button {
+    flex: 1;
+  }
+}
+</style>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -224,6 +224,13 @@ import('./page-inits/upstream-logistics-consumables')
         m.initUpstreamLogisticsConsumables)
   )
   .catch(() => {});
+import('./page-inits/stationary-combustion')
+  .then(
+    (m) =>
+      (pageInitializers['pages/stationary-combustion.html'] =
+        m.initStationaryCombustion)
+  )
+  .catch(() => {});
 
 const activeHref = ref('');
 const activeContent = ref('');

--- a/frontend/src/page-inits/stationary-combustion.ts
+++ b/frontend/src/page-inits/stationary-combustion.ts
@@ -1,0 +1,637 @@
+const LITER_PER_GALLON = 3.78541;
+
+type AuditStatus = 'Draft' | 'Submitted' | 'L1Approved' | 'L2Approved';
+
+type FuelType = '92 無鉛汽油' | '95 無鉛汽油' | '98 無鉛汽油' | '柴油';
+
+type CombustionRecord = {
+  depot: string;
+  activityId: string;
+  fuelType: FuelType;
+  month: number;
+  quantity: number;
+  unit: '公升' | '加侖';
+  dataSource: string;
+  notes?: string;
+  attachments: string[];
+};
+
+type ActivityDefinition = {
+  id: string;
+  name: string;
+  equipmentCode: string;
+  supportedFuels: FuelType[];
+};
+
+type FactorEntry = {
+  co2: number;
+  co2Unit: string;
+  co2Gwp: number;
+  ch4: number;
+  ch4Unit: string;
+  ch4Gwp: number;
+  n2o: number;
+  n2oUnit: string;
+  n2oGwp: number;
+  source: string;
+};
+
+type Option = { value: string | number; label: string };
+
+const INVENTORY_YEAR = 2024;
+const SITE_NAME = '中部營運總部';
+
+const DEPOT_OPTIONS = ['台中營運中心', '彰化配送據點', '南投備援倉'];
+
+const ACTIVITIES: ActivityDefinition[] = [
+  {
+    id: 'GEN-001',
+    name: '台中營運中心緊急發電機',
+    equipmentCode: 'GEN-001',
+    supportedFuels: ['柴油'],
+  },
+  {
+    id: 'GEN-002',
+    name: '倉儲棟後備發電機',
+    equipmentCode: 'GEN-002',
+    supportedFuels: ['92 無鉛汽油', '95 無鉛汽油'],
+  },
+  {
+    id: 'BO-101',
+    name: '鍋爐燃燒設備',
+    equipmentCode: 'BO-101',
+    supportedFuels: ['柴油', '98 無鉛汽油'],
+  },
+];
+
+const FACTOR_SOURCE = '環保署固定燃燒排放係數表 (2024 年度)';
+
+const FACTOR_TABLE: Record<FuelType, FactorEntry> = {
+  '92 無鉛汽油': {
+    co2: 2.32,
+    co2Unit: 'kg CO₂ / 公升',
+    co2Gwp: 1,
+    ch4: 0.00021,
+    ch4Unit: 'kg CH₄ / 公升',
+    ch4Gwp: 27.2,
+    n2o: 0.00021,
+    n2oUnit: 'kg N₂O / 公升',
+    n2oGwp: 273,
+    source: FACTOR_SOURCE,
+  },
+  '95 無鉛汽油': {
+    co2: 2.28,
+    co2Unit: 'kg CO₂ / 公升',
+    co2Gwp: 1,
+    ch4: 0.0002,
+    ch4Unit: 'kg CH₄ / 公升',
+    ch4Gwp: 27.2,
+    n2o: 0.00019,
+    n2oUnit: 'kg N₂O / 公升',
+    n2oGwp: 273,
+    source: FACTOR_SOURCE,
+  },
+  '98 無鉛汽油': {
+    co2: 2.26,
+    co2Unit: 'kg CO₂ / 公升',
+    co2Gwp: 1,
+    ch4: 0.00019,
+    ch4Unit: 'kg CH₄ / 公升',
+    ch4Gwp: 27.2,
+    n2o: 0.00019,
+    n2oUnit: 'kg N₂O / 公升',
+    n2oGwp: 273,
+    source: FACTOR_SOURCE,
+  },
+  '柴油': {
+    co2: 2.68,
+    co2Unit: 'kg CO₂ / 公升',
+    co2Gwp: 1,
+    ch4: 0.00005,
+    ch4Unit: 'kg CH₄ / 公升',
+    ch4Gwp: 27.2,
+    n2o: 0.00012,
+    n2oUnit: 'kg N₂O / 公升',
+    n2oGwp: 273,
+    source: FACTOR_SOURCE,
+  },
+};
+
+const ALL_FUELS = Object.keys(FACTOR_TABLE) as FuelType[];
+
+const numberFormatter = new Intl.NumberFormat('zh-TW', {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 2,
+});
+
+const emissionFormatter = new Intl.NumberFormat('zh-TW', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+export function initStationaryCombustion() {
+  const inventoryYearEl = document.getElementById('stationaryInventoryYear');
+  const statusLabel = document.getElementById('stationaryAuditStatus');
+  const actionContainer = document.getElementById('stationaryAuditActions');
+  const statusMessage = document.getElementById('stationaryAuditMessage');
+  const tableBody = document.getElementById('stationaryTableBody');
+  const emptyMessage = document.getElementById('stationaryEmptyMessage');
+  const addButton = document.getElementById('addCombustionRecordButton');
+  const addModal = document.getElementById('stationaryAddModal');
+  const addForm = document.getElementById('stationaryAddForm') as HTMLFormElement | null;
+  const depotSelect = document.getElementById('stationaryModalDepot') as HTMLSelectElement | null;
+  const activitySelect = document.getElementById('stationaryModalActivity') as HTMLSelectElement | null;
+  const fuelSelect = document.getElementById('stationaryModalFuel') as HTMLSelectElement | null;
+  const monthSelect = document.getElementById('stationaryModalMonth') as HTMLSelectElement | null;
+  const quantityInput = document.getElementById('stationaryModalQuantity') as HTMLInputElement | null;
+  const unitSelect = document.getElementById('stationaryModalUnit') as HTMLSelectElement | null;
+  const sourceInput = document.getElementById('stationaryModalSource') as HTMLInputElement | null;
+  const notesInput = document.getElementById('stationaryModalNotes') as HTMLTextAreaElement | null;
+  const attachmentInput = document.getElementById('stationaryModalAttachments') as HTMLInputElement | null;
+  const attachmentList = document.getElementById('stationaryModalAttachmentList');
+  const browseButton = document.getElementById('stationaryModalBrowse');
+  const dropZone = document.getElementById('stationaryModalDropZone');
+  const modalError = document.getElementById('stationaryModalError');
+  const returnModal = document.getElementById('stationaryReturnModal');
+  const returnForm = document.getElementById('stationaryReturnForm') as HTMLFormElement | null;
+  const returnReasonInput = document.getElementById('stationaryReturnReason') as HTMLTextAreaElement | null;
+  const returnError = document.getElementById('stationaryReturnError');
+
+  if (
+    !inventoryYearEl ||
+    !statusLabel ||
+    !actionContainer ||
+    !statusMessage ||
+    !tableBody ||
+    !emptyMessage ||
+    !addButton ||
+    !addModal ||
+    !addForm ||
+    !depotSelect ||
+    !activitySelect ||
+    !fuelSelect ||
+    !monthSelect ||
+    !quantityInput ||
+    !unitSelect ||
+    !sourceInput ||
+    !notesInput ||
+    !attachmentInput ||
+    !attachmentList ||
+    !browseButton ||
+    !dropZone ||
+    !modalError ||
+    !returnModal ||
+    !returnForm ||
+    !returnReasonInput ||
+    !returnError
+  ) {
+    return;
+  }
+
+  inventoryYearEl.textContent = `${INVENTORY_YEAR} 年`;
+
+  let currentStatus: AuditStatus = 'Draft';
+  let currentAttachments: string[] = [];
+  let presetContext: { depot?: string; activityId?: string; fuelType?: FuelType } | null = null;
+  let statusResetTimeout: number | undefined;
+
+  const records: CombustionRecord[] = [
+    {
+      depot: '台中營運中心',
+      activityId: 'GEN-001',
+      fuelType: '柴油',
+      month: 2,
+      quantity: 1850,
+      unit: '公升',
+      dataSource: '柴油採購紀錄-202402',
+      notes: '例行測試運轉 6 小時',
+      attachments: ['採購單_202402.pdf'],
+    },
+    {
+      depot: '彰化配送據點',
+      activityId: 'GEN-002',
+      fuelType: '95 無鉛汽油',
+      month: 3,
+      quantity: 320,
+      unit: '公升',
+      dataSource: '據點設備油品填報',
+      attachments: [],
+    },
+  ];
+
+  populateSelect(
+    depotSelect,
+    DEPOT_OPTIONS.map((label) => ({ value: label, label })),
+    '請選擇據點'
+  );
+  populateSelect(
+    activitySelect,
+    ACTIVITIES.map((activity) => ({ value: activity.id, label: activity.name })),
+    '請選擇活動/設備'
+  );
+  populateSelect(
+    monthSelect,
+    Array.from({ length: 12 }, (_, index) => ({ value: index + 1, label: `${index + 1} 月` })),
+    '請選擇月份'
+  );
+  setFuelOptionsForActivity('');
+
+  activitySelect.addEventListener('change', () => {
+    setFuelOptionsForActivity(activitySelect.value, fuelSelect.value as FuelType);
+  });
+
+  browseButton.addEventListener('click', () => attachmentInput.click());
+
+  attachmentInput.addEventListener('change', () => {
+    currentAttachments = collectAttachmentNames(attachmentInput.files);
+    renderAttachmentList(attachmentList, currentAttachments);
+  });
+
+  dropZone.addEventListener('dragover', (event) => {
+    event.preventDefault();
+    dropZone.classList.add('is-dragover');
+  });
+
+  dropZone.addEventListener('dragleave', () => {
+    dropZone.classList.remove('is-dragover');
+  });
+
+  dropZone.addEventListener('drop', (event) => {
+    event.preventDefault();
+    dropZone.classList.remove('is-dragover');
+    const files = event.dataTransfer?.files;
+    currentAttachments = collectAttachmentNames(files || null);
+    renderAttachmentList(attachmentList, currentAttachments);
+  });
+
+  addButton.addEventListener('click', () => {
+    presetContext = null;
+    openAddModal();
+  });
+
+  Array.from(addModal.querySelectorAll('[data-close-modal]')).forEach((element) => {
+    element.addEventListener('click', () => closeModal(addModal));
+  });
+
+  Array.from(returnModal.querySelectorAll('[data-close-modal]')).forEach((element) => {
+    element.addEventListener('click', () => closeModal(returnModal));
+  });
+
+  addForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    modalError.textContent = '';
+
+    const depot = depotSelect.value;
+    const activityId = activitySelect.value;
+    const fuelType = fuelSelect.value as FuelType;
+    const month = Number(monthSelect.value);
+    const quantity = Number(quantityInput.value);
+    const unit = unitSelect.value as '公升' | '加侖';
+    const dataSource = sourceInput.value.trim();
+    const notes = notesInput.value.trim();
+
+    if (!depot || !activityId || !fuelType || !month || !Number.isFinite(quantity) || quantity < 0 || !dataSource) {
+      modalError.textContent = '請確認已填寫所有必填欄位，並且採購量不可為負數。';
+      return;
+    }
+
+    const record: CombustionRecord = {
+      depot,
+      activityId,
+      fuelType,
+      month,
+      quantity,
+      unit,
+      dataSource,
+      notes: notes ? notes : undefined,
+      attachments: [...currentAttachments],
+    };
+
+    records.push(record);
+    renderTable();
+    addForm.reset();
+    currentAttachments = [];
+    renderAttachmentList(attachmentList, currentAttachments);
+    closeModal(addModal);
+    presetContext = null;
+  });
+
+  returnForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const reason = returnReasonInput.value.trim();
+    if (!reason) {
+      returnError.textContent = '退回原因為必填欄位。';
+      return;
+    }
+
+    currentStatus = 'Draft';
+    updateStatusUI('資料已退回，原因：' + reason);
+    closeModal(returnModal);
+    returnForm.reset();
+    returnError.textContent = '';
+  });
+
+  returnForm.addEventListener('reset', () => {
+    returnError.textContent = '';
+  });
+
+  updateStatusUI();
+  renderTable();
+
+  function openAddModal() {
+    if (presetContext?.depot) {
+      depotSelect.value = presetContext.depot;
+    } else if (DEPOT_OPTIONS.length === 1) {
+      depotSelect.value = DEPOT_OPTIONS[0];
+    } else {
+      depotSelect.value = '';
+    }
+
+    if (presetContext?.activityId) {
+      activitySelect.value = presetContext.activityId;
+    } else {
+      activitySelect.value = '';
+    }
+
+    setFuelOptionsForActivity(activitySelect.value, presetContext?.fuelType);
+
+    monthSelect.value = '';
+    quantityInput.value = '';
+    unitSelect.value = '公升';
+    sourceInput.value = '';
+    notesInput.value = '';
+    modalError.textContent = '';
+    currentAttachments = [];
+    renderAttachmentList(attachmentList, currentAttachments);
+
+    openModal(addModal);
+    depotSelect.focus();
+  }
+
+  function renderTable() {
+    tableBody.innerHTML = '';
+    if (records.length === 0) {
+      emptyMessage.hidden = false;
+      return;
+    }
+
+    emptyMessage.hidden = true;
+
+    records.forEach((record) => {
+      const activity = getActivityDefinition(record.activityId);
+      const factor = FACTOR_TABLE[record.fuelType];
+      const row = document.createElement('tr');
+
+      const actionCell = document.createElement('td');
+      actionCell.classList.add('col-actions');
+      const createButton = document.createElement('button');
+      createButton.type = 'button';
+      createButton.className = 'secondary-button';
+      createButton.textContent = '新增';
+      createButton.addEventListener('click', () => {
+        presetContext = {
+          depot: record.depot,
+          activityId: record.activityId,
+          fuelType: record.fuelType,
+        };
+        openAddModal();
+      });
+      actionCell.appendChild(createButton);
+      row.appendChild(actionCell);
+
+      row.appendChild(createCell(SITE_NAME));
+      row.appendChild(createCell(record.depot, true));
+      row.appendChild(createCell(activity?.name || record.activityId, true));
+      row.appendChild(createCell(activity?.equipmentCode || '—'));
+      row.appendChild(createCell(record.fuelType, true));
+      row.appendChild(createCell(`${record.month} 月`, true));
+      row.appendChild(createCell(numberFormatter.format(record.quantity), true));
+      row.appendChild(createCell(record.unit, true));
+
+      if (factor) {
+        row.appendChild(createCell(factor.co2.toFixed(5)));
+        row.appendChild(createCell(factor.co2Unit));
+        row.appendChild(createCell(numberFormatter.format(factor.co2Gwp)));
+        row.appendChild(createCell(factor.ch4.toExponential(5)));
+        row.appendChild(createCell(factor.ch4Unit));
+        row.appendChild(createCell(numberFormatter.format(factor.ch4Gwp)));
+        row.appendChild(createCell(factor.n2o.toExponential(5)));
+        row.appendChild(createCell(factor.n2oUnit));
+        row.appendChild(createCell(numberFormatter.format(factor.n2oGwp)));
+
+        const quantityInLiters = record.unit === '加侖' ? record.quantity * LITER_PER_GALLON : record.quantity;
+        const emission =
+          quantityInLiters * factor.co2 * factor.co2Gwp +
+          quantityInLiters * factor.ch4 * factor.ch4Gwp +
+          quantityInLiters * factor.n2o * factor.n2oGwp;
+        row.appendChild(createCell(emissionFormatter.format(emission)));
+      } else {
+        row.appendChild(createCell('—'));
+        row.appendChild(createCell('—'));
+        row.appendChild(createCell('—'));
+        row.appendChild(createCell('—'));
+        row.appendChild(createCell('—'));
+        row.appendChild(createCell('—'));
+        row.appendChild(createCell('—'));
+        row.appendChild(createCell('—'));
+        row.appendChild(createCell('—'));
+        row.appendChild(createCell('—'));
+      }
+
+      row.appendChild(createCell(record.dataSource, true));
+      row.appendChild(createCell(factor?.source || FACTOR_SOURCE));
+      row.appendChild(createCell(record.notes || '—', true));
+
+      tableBody.appendChild(row);
+    });
+  }
+
+  function updateStatusUI(message?: string) {
+    statusLabel.textContent = getStatusLabel(currentStatus);
+    statusLabel.className = `status-badge ${getStatusClass(currentStatus)}`;
+    renderStatusActions();
+
+    statusMessage.textContent = message ?? '';
+
+    if (statusResetTimeout) {
+      window.clearTimeout(statusResetTimeout);
+    }
+
+    if (message) {
+      statusResetTimeout = window.setTimeout(() => {
+        statusMessage.textContent = '';
+      }, 5000);
+    }
+  }
+
+  function renderStatusActions() {
+    actionContainer.innerHTML = '';
+
+    if (currentStatus === 'Draft') {
+      const submitButton = createActionButton('送審', () => {
+        currentStatus = 'Submitted';
+        updateStatusUI('資料已送出審核。');
+      });
+      actionContainer.appendChild(submitButton);
+      return;
+    }
+
+    if (currentStatus === 'Submitted' || currentStatus === 'L1Approved') {
+      const approveButton = createActionButton('審核通過', () => {
+        if (currentStatus === 'Submitted') {
+          currentStatus = 'L1Approved';
+          updateStatusUI('已完成第一階段審核。');
+        } else {
+          currentStatus = 'L2Approved';
+          updateStatusUI('資料已完成審核流程。');
+        }
+      });
+
+      const returnButton = createActionButton('退回', () => {
+        returnReasonInput.value = '';
+        returnError.textContent = '';
+        openModal(returnModal);
+        returnReasonInput.focus();
+      }, true);
+
+      actionContainer.appendChild(approveButton);
+      actionContainer.appendChild(returnButton);
+      return;
+    }
+  }
+
+  function openModal(modal: HTMLElement) {
+    modal.setAttribute('aria-hidden', 'false');
+    document.addEventListener('keydown', handleEscape, { once: true });
+  }
+
+  function closeModal(modal: HTMLElement) {
+    modal.setAttribute('aria-hidden', 'true');
+  }
+
+  function handleEscape(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      if (addModal.getAttribute('aria-hidden') === 'false') {
+        closeModal(addModal);
+      }
+      if (returnModal.getAttribute('aria-hidden') === 'false') {
+        closeModal(returnModal);
+      }
+    }
+  }
+
+  function createCell(value: string, editable = false) {
+    const cell = document.createElement('td');
+    cell.textContent = value;
+    if (editable) {
+      cell.classList.add('editable-cell');
+    }
+    return cell;
+  }
+
+  function createActionButton(label: string, handler: () => void, isSecondary = false) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = isSecondary ? 'secondary-button' : 'primary-button';
+    button.textContent = label;
+    button.addEventListener('click', handler);
+    return button;
+  }
+
+  function getStatusLabel(status: AuditStatus) {
+    switch (status) {
+      case 'Draft':
+        return '草稿';
+      case 'Submitted':
+        return '待審核';
+      case 'L1Approved':
+        return '一階審核通過';
+      case 'L2Approved':
+        return '二階審核通過';
+      default:
+        return '';
+    }
+  }
+
+  function getStatusClass(status: AuditStatus) {
+    switch (status) {
+      case 'Draft':
+        return 'status-badge--draft';
+      case 'Submitted':
+        return 'status-badge--submitted';
+      case 'L1Approved':
+        return 'status-badge--l1';
+      case 'L2Approved':
+        return 'status-badge--l2';
+      default:
+        return 'status-badge--draft';
+    }
+  }
+
+  function populateSelect(select: HTMLSelectElement, options: Option[], placeholder: string) {
+    select.innerHTML = '';
+
+    const placeholderOption = document.createElement('option');
+    placeholderOption.value = '';
+    placeholderOption.textContent = placeholder;
+    placeholderOption.disabled = true;
+    placeholderOption.selected = true;
+    select.appendChild(placeholderOption);
+
+    options.forEach((option) => {
+      const element = document.createElement('option');
+      element.value = String(option.value);
+      element.textContent = option.label;
+      select.appendChild(element);
+    });
+  }
+
+  function populateFuelOptions(select: HTMLSelectElement, fuels: FuelType[], selected?: FuelType) {
+    select.innerHTML = '';
+
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = '請選擇油品';
+    placeholder.disabled = true;
+    if (!selected) {
+      placeholder.selected = true;
+    }
+    select.appendChild(placeholder);
+
+    fuels.forEach((fuel) => {
+      const option = document.createElement('option');
+      option.value = fuel;
+      option.textContent = fuel;
+      if (fuel === selected) {
+        option.selected = true;
+      }
+      select.appendChild(option);
+    });
+  }
+
+  function setFuelOptionsForActivity(activityId: string, selectedFuel?: FuelType) {
+    const activity = getActivityDefinition(activityId);
+    const fuels = activity ? activity.supportedFuels : ALL_FUELS;
+    populateFuelOptions(fuelSelect, fuels, selectedFuel && fuels.includes(selectedFuel) ? selectedFuel : undefined);
+  }
+
+  function collectAttachmentNames(fileList: FileList | null) {
+    if (!fileList || fileList.length === 0) {
+      return [];
+    }
+    return Array.from(fileList).map((file) => file.name);
+  }
+
+  function renderAttachmentList(container: HTMLElement, attachments: string[]) {
+    container.innerHTML = '';
+    attachments.forEach((name) => {
+      const item = document.createElement('li');
+      item.textContent = name;
+      container.appendChild(item);
+    });
+  }
+
+  function getActivityDefinition(id: string) {
+    return ACTIVITIES.find((activity) => activity.id === id) || null;
+  }
+}


### PR DESCRIPTION
## Summary
- implement the stationary combustion activity collection page with review controls, activity table, and modals
- add a dedicated initializer to drive status transitions, factor lookups, emission calculations, and table rendering
- register the new initializer with the Vue shell so the page loads dynamically

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbeea49d84832096f017e03136fe96