### PR TITLE
Add inline add button for business travel records

### DIFF
--- a/frontend/pages/business-travel.html
+++ b/frontend/pages/business-travel.html
@@ -43,6 +43,16 @@
       <table class="data-table travel-table" aria-describedby="inventoryYearDisplay">
         <thead>
           <tr>
+            <th scope="col" class="table-action-column">
+              <button
+                id="tableAddTravelButton"
+                class="table-add-button"
+                type="button"
+                aria-label="新增活動資料"
+              >
+                新增
+              </button>
+            </th>
             <th scope="col">公司名稱</th>
             <th scope="col">據點名稱</th>
             <th scope="col">出發日期</th>
@@ -357,6 +367,43 @@
 .data-table td {
   background: #ffffff;
   color: #1f2933;
+}
+
+.table-action-column {
+  width: 96px;
+  text-align: center;
+}
+
+.table-add-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid #2563eb;
+  background: #f8fafc;
+  color: #2563eb;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.table-add-button:hover {
+  background: #2563eb;
+  color: #ffffff;
+  box-shadow: 0 6px 16px rgba(37, 99, 235, 0.25);
+}
+
+.table-add-button:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.3);
+}
+
+.table-action-cell {
+  background: #f9fafb;
+  text-align: center;
 }
 
 .data-table td.is-editable-cell {

--- a/frontend/src/page-inits/business-travel.ts
+++ b/frontend/src/page-inits/business-travel.ts
@@ -179,6 +179,7 @@ export function initBusinessTravel() {
   const dropZone = document.getElementById('attachmentDropZone');
   const browseButton = document.getElementById('browseAttachmentButton');
   const addError = document.getElementById('addRecordError');
+  const tableAddButton = document.getElementById('tableAddTravelButton');
   const reasonModal = document.getElementById('returnReasonModal');
   const reasonForm = document.getElementById('returnReasonForm') as HTMLFormElement | null;
   const reasonInput = document.getElementById('returnReasonInput') as HTMLTextAreaElement | null;
@@ -202,6 +203,7 @@ export function initBusinessTravel() {
     !dropZone ||
     !browseButton ||
     !addError ||
+    !tableAddButton ||
     !reasonModal ||
     !reasonForm ||
     !reasonInput ||
@@ -220,7 +222,10 @@ export function initBusinessTravel() {
   renderStatus();
   syncCabinAvailability(transportSelect, cabinSelect);
 
-  addButton.addEventListener('click', () => openModal(addModal));
+  const openAddRecordModal = () => openModal(addModal);
+
+  addButton.addEventListener('click', openAddRecordModal);
+  tableAddButton.addEventListener('click', openAddRecordModal);
   addModal.querySelectorAll('[data-close-modal]').forEach((element) => {
     element.addEventListener('click', () => closeModal(addModal));
   });
@@ -421,6 +426,8 @@ export function initBusinessTravel() {
     const row = document.createElement('tr');
     row.dataset.id = record.id;
 
+    row.appendChild(createActionCell());
+
     row.appendChild(createTextCell(record.company));
 
     row.appendChild(
@@ -600,6 +607,12 @@ export function initBusinessTravel() {
     return row;
   }
 
+  function createActionCell() {
+    const cell = document.createElement('td');
+    cell.className = 'table-action-cell';
+    return cell;
+  }
+
   function createTextCell(text: string) {
     const cell = document.createElement('td');
     cell.textContent = text;
@@ -679,7 +692,8 @@ export function initBusinessTravel() {
     placeholder?: string
   ) {
     select.innerHTML = '';
-    if (placeholder) {
+    const shouldUsePlaceholder = Boolean(placeholder) && options.length > 1;
+    if (shouldUsePlaceholder) {
       const option = document.createElement('option');
       option.value = '';
       option.textContent = placeholder;
@@ -693,6 +707,9 @@ export function initBusinessTravel() {
       option.textContent = item.label;
       select.appendChild(option);
     });
+    if (!shouldUsePlaceholder && options.length > 0) {
+      select.value = options[0].value;
+    }
   }
 
   function createSelect(options: string[], value: string) {


### PR DESCRIPTION
## Summary
- add an inline "新增" control to the business travel activity table header that opens the existing add record modal
- style the new column and maintain row alignment with a dedicated action cell
- ensure single-option selects default to their only value to reduce user input

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbf8e291ec8320b34fc4347778ba13