### PR TITLE
Load CSV-backed data for reporting tables

### DIFF
--- a/frontend/public/data/business-travel.csv
+++ b/frontend/public/data/business-travel.csv
@@ -1,0 +1,3 @@
+id,company,site,departureDate,transportation,cabinClass,origin,destination,dailyTrips,passengers,distanceKm,dataSource,attachments,notes
+rec-1,綠程科技股份有限公司,台北總部,2024-03-12,plane,economy,台北,東京,2,2,2140,差旅平台匯出,20240312_flight.pdf,去回程皆為經濟艙
+rec-2,綠程科技股份有限公司,新竹研發中心,2024-04-08,hsr,,新竹,高雄,2,1,345,出差報銷單,hsr-ticket.png,

--- a/frontend/public/data/stationary-combustion.csv
+++ b/frontend/public/data/stationary-combustion.csv
@@ -1,0 +1,3 @@
+depot,activityId,fuelType,month,quantity,unit,dataSource,notes,attachments
+台中營運中心,GEN-001,柴油,2,1850,公升,柴油採購紀錄-202402,例行測試運轉 6 小時,採購單_202402.pdf
+彰化配送據點,GEN-002,95 無鉛汽油,3,320,公升,據點設備油品填報,,

--- a/frontend/public/data/upstream-logistics-consumables.csv
+++ b/frontend/public/data/upstream-logistics-consumables.csv
@@ -1,0 +1,3 @@
+location,month,item,vehicle,fuelType,origin,destination,quantity,unitWeightKg,distanceKm,dataSource,factorSource,attachments,notes
+北一倉儲中心,3,瓦楞紙箱 (大),3.5T 小貨車,柴油,台北市,台中市,320,0.85,170,物流系統出貨紀錄,交通運輸排放係數資料庫 2024 年版,出貨單據_20240315.pdf,
+桃園轉運倉,4,棧板,7.5T 大貨車,柴油,桃園市,高雄市,42,12,330,外包物流運送紀錄,交通運輸排放係數資料庫 2024 年版,,棧板回收循環使用

--- a/frontend/src/utils/csv-loader.ts
+++ b/frontend/src/utils/csv-loader.ts
@@ -1,0 +1,70 @@
+export type CsvRow = Record<string, string>;
+
+export async function loadCsvRows(path: string): Promise<CsvRow[]> {
+  const response = await fetch(path, { cache: 'no-store' });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load CSV from ${path}: ${response.status} ${response.statusText}`);
+  }
+
+  const text = await response.text();
+  return parseCsv(text);
+}
+
+function parseCsv(csvText: string): CsvRow[] {
+  const normalized = csvText.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n');
+  const lines = normalized.split('\n').filter((line) => line.trim().length > 0);
+
+  if (lines.length === 0) {
+    return [];
+  }
+
+  const headers = parseCsvLine(lines[0]).map((header) => header.trim());
+  const rows: CsvRow[] = [];
+
+  for (let i = 1; i < lines.length; i += 1) {
+    const values = parseCsvLine(lines[i]);
+    if (values.every((value) => value.trim().length === 0)) {
+      continue;
+    }
+
+    const row: CsvRow = {};
+    headers.forEach((header, index) => {
+      row[header] = (values[index] ?? '').trim();
+    });
+
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+function parseCsvLine(line: string): string[] {
+  const values: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (char === ',' && !inQuotes) {
+      values.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  values.push(current);
+  return values;
+}


### PR DESCRIPTION
## Summary
- add reusable CSV parsing helper and seed CSV files for travel, combustion, and consumable tables
- initialize each affected page by fetching its CSV dataset instead of hard-coded records
- keep existing interactions intact by re-rendering tables after the asynchronous load completes

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68dc73c5465c8320a648eef75db333c3