### PR TITLE
Add inventory summary filters and mock downloads

### DIFF
--- a/frontend/pages/inventory-summary.html
+++ b/frontend/pages/inventory-summary.html
@@ -1,4 +1,496 @@
-<section class="page-content">
-  <h1>清冊簡表</h1>
-  <p>總覽各排放源的關鍵指標與當期排放彙整。</p>
+<section class="page-content inventory-summary" aria-labelledby="inventorySummaryTitle">
+  <header class="page-header">
+    <h1 id="inventorySummaryTitle">清冊簡表</h1>
+    <p>查詢各站點的清冊簡表進度並匯出對應站點與排放源的 Excel 簡表。</p>
+  </header>
+
+  <section class="filters" aria-label="清冊簡表查詢條件">
+    <form id="inventorySummaryFilters" class="filters-form">
+      <div class="form-grid">
+        <div class="form-field">
+          <label for="filterYear">年度</label>
+          <select id="filterYear" name="year"></select>
+        </div>
+        <div class="form-field">
+          <label for="filterCountry">國家</label>
+          <select id="filterCountry" name="country">
+            <option value="">全部</option>
+          </select>
+        </div>
+        <div class="form-field">
+          <label for="filterRegion">區域</label>
+          <select id="filterRegion" name="region">
+            <option value="">全部</option>
+          </select>
+        </div>
+        <div class="form-field">
+          <label for="filterSite">站點</label>
+          <select id="filterSite" name="site">
+            <option value="">全部</option>
+          </select>
+        </div>
+        <div class="form-field">
+          <label for="filterStatus">審核狀態</label>
+          <select id="filterStatus" name="status">
+            <option value="">全部</option>
+          </select>
+        </div>
+      </div>
+      <div class="form-actions">
+        <button class="primary-button" type="submit">查詢</button>
+        <button class="secondary-button" type="reset">清除條件</button>
+      </div>
+    </form>
+  </section>
+
+  <section class="results" aria-live="polite">
+    <div class="results-header">
+      <h2>查詢結果</h2>
+      <p class="results-subtitle">依據篩選條件顯示站點進度與排放源列表。</p>
+    </div>
+
+    <div class="table-wrapper" role="region" aria-label="清冊簡表結果表格">
+      <table class="result-table">
+        <thead>
+          <tr>
+            <th scope="col">年分</th>
+            <th scope="col">國家</th>
+            <th scope="col">區域</th>
+            <th scope="col">站點</th>
+            <th scope="col">排放源</th>
+            <th scope="col">審核狀態</th>
+            <th scope="col">匯出</th>
+          </tr>
+        </thead>
+        <tbody id="inventorySummaryTableBody"></tbody>
+      </table>
+      <p id="inventorySummaryEmpty" class="empty-hint" hidden>無符合條件的資料。</p>
+    </div>
+    <div id="inventorySummaryMessage" class="sr-only" aria-live="assertive"></div>
+  </section>
 </section>
+
+<script>
+  (function () {
+    const statusStages = [
+      { value: '', label: '全部' },
+      { value: 'Draft', label: 'Draft (0%)' },
+      { value: 'Submitted', label: 'Submitted (50%)' },
+      { value: 'L1Approved', label: 'L1Approved (75%)' },
+      { value: 'L2Approved', label: 'L2Approved (100%)' }
+    ];
+
+    const statusPercentage = {
+      Draft: 0,
+      Submitted: 50,
+      L1Approved: 75,
+      L2Approved: 100
+    };
+
+    const summaryData = [
+      {
+        year: 2023,
+        country: '台灣',
+        region: '北亞營運區',
+        site: 'DIMTPE',
+        emissionSources: ['固定燃燒排放', '輸入電力的間接排放'],
+        status: 'Submitted'
+      },
+      {
+        year: 2023,
+        country: '中國',
+        region: '華東營運區',
+        site: 'DIMSHA',
+        emissionSources: ['固定燃燒排放', '逸散性排放', '物流運輸排放 (陸運)'],
+        status: 'L1Approved'
+      },
+      {
+        year: 2024,
+        country: '美國',
+        region: '北美營運區',
+        site: 'DIMLAX',
+        emissionSources: ['物流貨物運輸', '上游運輸物流經常耗材'],
+        status: 'Draft'
+      },
+      {
+        year: 2024,
+        country: '越南',
+        region: '東協營運區',
+        site: 'DIMSGN',
+        emissionSources: ['固定燃燒排放', '商務差旅'],
+        status: 'L2Approved'
+      }
+    ];
+
+    const form = document.getElementById('inventorySummaryFilters');
+    const yearSelect = document.getElementById('filterYear');
+    const countrySelect = document.getElementById('filterCountry');
+    const regionSelect = document.getElementById('filterRegion');
+    const siteSelect = document.getElementById('filterSite');
+    const statusSelect = document.getElementById('filterStatus');
+    const tableBody = document.getElementById('inventorySummaryTableBody');
+    const emptyHint = document.getElementById('inventorySummaryEmpty');
+    const messageContainer = document.getElementById('inventorySummaryMessage');
+
+    function getUniqueValues(key) {
+      return Array.from(new Set(summaryData.map((item) => item[key])));
+    }
+
+    function populateSelect(select, options, { addAllOption = false } = {}) {
+      const fragment = document.createDocumentFragment();
+      if (addAllOption) {
+        const allOption = document.createElement('option');
+        allOption.value = '';
+        allOption.textContent = '全部';
+        fragment.appendChild(allOption);
+      }
+
+      options.forEach((option) => {
+        const optionElement = document.createElement('option');
+        if (typeof option === 'object') {
+          optionElement.value = option.value;
+          optionElement.textContent = option.label;
+        } else {
+          optionElement.value = option;
+          optionElement.textContent = option;
+        }
+        fragment.appendChild(optionElement);
+      });
+
+      select.innerHTML = '';
+      select.appendChild(fragment);
+    }
+
+    function populateFilters() {
+      const currentYear = new Date().getFullYear();
+      const years = Array.from(
+        new Set([
+          currentYear - 2,
+          currentYear - 1,
+          currentYear,
+          ...summaryData.map((item) => item.year)
+        ])
+      )
+        .sort()
+        .reverse();
+
+      populateSelect(yearSelect, years);
+      const defaultYear = currentYear - 1;
+      if (years.includes(defaultYear)) {
+        yearSelect.value = String(defaultYear);
+      }
+
+      populateSelect(countrySelect, getUniqueValues('country'), { addAllOption: true });
+      populateSelect(regionSelect, getUniqueValues('region'), { addAllOption: true });
+      populateSelect(siteSelect, getUniqueValues('site'), { addAllOption: true });
+      populateSelect(statusSelect, statusStages);
+    }
+
+    function formatStatus(status) {
+      if (!status) {
+        return '未指定';
+      }
+
+      const percentage = statusPercentage[status];
+      if (typeof percentage === 'number') {
+        return `${status} (${percentage}%)`;
+      }
+
+      return status;
+    }
+
+    function renderRows(data) {
+      tableBody.innerHTML = '';
+
+      if (!data.length) {
+        emptyHint.hidden = false;
+        return;
+      }
+
+      emptyHint.hidden = true;
+
+      const fragment = document.createDocumentFragment();
+      data.forEach((item) => {
+        const row = document.createElement('tr');
+
+        const siteLink = document.createElement('button');
+        siteLink.type = 'button';
+        siteLink.className = 'link-button';
+        siteLink.textContent = item.site;
+        siteLink.dataset.site = item.site;
+        siteLink.addEventListener('click', () => simulateDownload(`${item.site} 清冊簡表`));
+
+        const downloadButton = document.createElement('button');
+        downloadButton.type = 'button';
+        downloadButton.className = 'secondary-button download-button';
+        downloadButton.textContent = '下載';
+        downloadButton.addEventListener('click', () =>
+          simulateDownload(`${item.site} - ${item.year} 匯出資料`)
+        );
+
+        const cells = [
+          item.year,
+          item.country,
+          item.region,
+          siteLink,
+          item.emissionSources.join('、'),
+          formatStatus(item.status),
+          downloadButton
+        ];
+
+        cells.forEach((value) => {
+          const cell = document.createElement('td');
+          if (value instanceof HTMLElement) {
+            cell.appendChild(value);
+          } else {
+            cell.textContent = value;
+          }
+          row.appendChild(cell);
+        });
+
+        fragment.appendChild(row);
+      });
+
+      tableBody.appendChild(fragment);
+    }
+
+    function simulateDownload(text) {
+      if (messageContainer) {
+        messageContainer.textContent = `${text} 的 Excel 檔案下載已模擬完成。`;
+      }
+      window.setTimeout(() => {
+        if (messageContainer) {
+          messageContainer.textContent = '';
+        }
+      }, 3000);
+    }
+
+    function applyFilters() {
+      const formData = new FormData(form);
+      const filters = {
+        year: formData.get('year'),
+        country: formData.get('country'),
+        region: formData.get('region'),
+        site: formData.get('site'),
+        status: formData.get('status')
+      };
+
+      const filtered = summaryData.filter((item) => {
+        return (
+          (!filters.year || String(item.year) === filters.year) &&
+          (!filters.country || item.country === filters.country) &&
+          (!filters.region || item.region === filters.region) &&
+          (!filters.site || item.site === filters.site) &&
+          (!filters.status || item.status === filters.status)
+        );
+      });
+
+      renderRows(filtered);
+    }
+
+    function handleSubmit(event) {
+      event.preventDefault();
+      applyFilters();
+    }
+
+    function handleReset() {
+      window.setTimeout(() => {
+        const defaultYear = String(new Date().getFullYear() - 1);
+        if (Array.from(yearSelect.options).some((option) => option.value === defaultYear)) {
+          yearSelect.value = defaultYear;
+        }
+        applyFilters();
+      }, 0);
+    }
+
+    function initialize() {
+      if (!form) {
+        return;
+      }
+
+      populateFilters();
+      applyFilters();
+      form.addEventListener('submit', handleSubmit);
+      form.addEventListener('reset', handleReset);
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', initialize, { once: true });
+    } else {
+      initialize();
+    }
+  })();
+</script>
+
+<style>
+  .inventory-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  }
+
+  .inventory-summary .page-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .inventory-summary .page-header h1 {
+    margin: 0;
+    font-size: 2rem;
+    color: #111827;
+  }
+
+  .inventory-summary .page-header p {
+    margin: 0;
+    color: #4b5563;
+    line-height: 1.6;
+  }
+
+  .inventory-summary .filters {
+    background-color: #f9fafb;
+    border-radius: 12px;
+    border: 1px solid #e5e7eb;
+    padding: 1.5rem;
+  }
+
+  .inventory-summary .filters-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .inventory-summary .form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+  }
+
+  .inventory-summary .form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .inventory-summary label {
+    font-weight: 600;
+    color: #111827;
+  }
+
+  .inventory-summary select {
+    appearance: none;
+    background-color: #fff;
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.95rem;
+    color: #1f2937;
+  }
+
+  .inventory-summary .form-actions {
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  .inventory-summary .results {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .inventory-summary .results-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .inventory-summary .results-header h2 {
+    margin: 0;
+    font-size: 1.5rem;
+    color: #111827;
+  }
+
+  .inventory-summary .results-subtitle {
+    margin: 0;
+    color: #4b5563;
+  }
+
+  .inventory-summary .table-wrapper {
+    background-color: #ffffff;
+    border-radius: 12px;
+    border: 1px solid #e5e7eb;
+    overflow-x: auto;
+  }
+
+  .inventory-summary .result-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 720px;
+  }
+
+  .inventory-summary .result-table th,
+  .inventory-summary .result-table td {
+    padding: 0.75rem 1rem;
+    text-align: left;
+    border-bottom: 1px solid #e5e7eb;
+    vertical-align: top;
+    color: #1f2937;
+  }
+
+  .inventory-summary .result-table th {
+    background-color: #f3f4f6;
+    font-weight: 700;
+    color: #111827;
+  }
+
+  .inventory-summary .result-table tbody tr:last-child td {
+    border-bottom: none;
+  }
+
+  .inventory-summary .empty-hint {
+    margin: 1rem;
+    color: #6b7280;
+  }
+
+  .inventory-summary .download-button {
+    font-size: 0.9rem;
+    padding: 0.4rem 0.75rem;
+  }
+
+  .inventory-summary .link-button {
+    background: none;
+    border: none;
+    color: #2563eb;
+    cursor: pointer;
+    padding: 0;
+    font: inherit;
+  }
+
+  .inventory-summary .link-button:hover,
+  .inventory-summary .link-button:focus {
+    text-decoration: underline;
+  }
+
+  .inventory-summary .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  @media (max-width: 640px) {
+    .inventory-summary .form-actions {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .inventory-summary .download-button {
+      width: 100%;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- build out the inventory summary page with query filters and a results table
- simulate per-site and overall Excel downloads with accessible status messaging

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcacc913f48320b75e7d008b20ff44