### PR TITLE
Add expanded sample data for inventory summary table

### DIFF
--- a/frontend/pages/inventory-summary.html
+++ b/frontend/pages/inventory-summary.html
@@ -119,6 +119,54 @@
         site: 'DIMSGN',
         emissionSources: ['固定燃燒排放', '商務差旅'],
         status: 'L2Approved'
+      },
+      {
+        year: 2022,
+        country: '日本',
+        region: '北亞營運區',
+        site: 'DIMNRT',
+        emissionSources: ['製程逸散排放', '購買冷媒', '業務差旅'],
+        status: 'Draft'
+      },
+      {
+        year: 2022,
+        country: '德國',
+        region: '歐洲營運區',
+        site: 'DIMFRA',
+        emissionSources: ['固定燃燒排放', '輸入蒸氣的間接排放'],
+        status: 'Submitted'
+      },
+      {
+        year: 2023,
+        country: '印度',
+        region: '南亞營運區',
+        site: 'DIMBLR',
+        emissionSources: ['逸散性排放', '產品使用排放', '員工通勤'],
+        status: 'L1Approved'
+      },
+      {
+        year: 2023,
+        country: '墨西哥',
+        region: '拉美營運區',
+        site: 'DIMMEX',
+        emissionSources: ['物流運輸排放 (海運)', '租賃資產能源使用'],
+        status: 'L2Approved'
+      },
+      {
+        year: 2024,
+        country: '澳大利亞',
+        region: '大洋洲營運區',
+        site: 'DIMSYD',
+        emissionSources: ['固定燃燒排放', '自有車隊燃料使用'],
+        status: 'Draft'
+      },
+      {
+        year: 2024,
+        country: '新加坡',
+        region: '東協營運區',
+        site: 'DIMSIN',
+        emissionSources: ['物流貨物運輸', '外購蒸氣'],
+        status: 'Submitted'
       }
     ];
 


### PR DESCRIPTION
## Summary
- expand the inventory summary mock dataset to include 10 diverse records for filtering and download simulations

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68dcbcb5e4e083208f192c1584b3b430