### PR TITLE
Add dual download buttons to inventory summary page

### DIFF
--- a/frontend/pages/inventory-summary.html
+++ b/frontend/pages/inventory-summary.html
@@ -195,6 +195,13 @@
     border-bottom: none;
   }
 
+  .inventory-summary .download-button-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: flex-start;
+  }
+
   .inventory-summary .empty-hint {
     margin: 1rem;
     color: #6b7280;

--- a/frontend/src/page-inits/inventory-summary.ts
+++ b/frontend/src/page-inits/inventory-summary.ts
@@ -169,13 +169,25 @@ function renderRows(
     siteLink.dataset.site = item.site;
     siteLink.addEventListener('click', () => simulateDownload(messageContainer, `${item.site} 清冊簡表`));
 
-    const downloadButton = document.createElement('button');
-    downloadButton.type = 'button';
-    downloadButton.className = 'secondary-button download-button';
-    downloadButton.textContent = '下載';
-    downloadButton.addEventListener('click', () =>
-      simulateDownload(messageContainer, `${item.site} - ${item.year} 匯出資料`)
+    const downloadSimpleButton = document.createElement('button');
+    downloadSimpleButton.type = 'button';
+    downloadSimpleButton.className = 'secondary-button download-button';
+    downloadSimpleButton.textContent = '下載簡表';
+    downloadSimpleButton.addEventListener('click', () =>
+      simulateDownload(messageContainer, `${item.site} - ${item.year} 清冊簡表`)
     );
+
+    const downloadAllButton = document.createElement('button');
+    downloadAllButton.type = 'button';
+    downloadAllButton.className = 'secondary-button download-button';
+    downloadAllButton.textContent = '下載簡表與所有活動';
+    downloadAllButton.addEventListener('click', () =>
+      simulateDownload(messageContainer, `${item.site} - ${item.year} 清冊簡表與所有活動`)
+    );
+
+    const downloadButtons = document.createElement('div');
+    downloadButtons.className = 'download-button-group';
+    downloadButtons.append(downloadSimpleButton, downloadAllButton);
 
     const cells: (string | number | HTMLElement)[] = [
       item.year,
@@ -184,7 +196,7 @@ function renderRows(
       siteLink,
       item.emissionSources.join('、'),
       formatStatus(item.status),
-      downloadButton,
+      downloadButtons,
     ];
 
     cells.forEach((value) => {


### PR DESCRIPTION
## Summary
- replace the inventory summary export column with separate buttons for downloading the simple sheet and the sheet with all activities
- add layout styling so the new download buttons stack neatly in the results table

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68dcc04a2ec8832093c188b32c1b45f8