### PR TITLE
Add attachment support to stationary combustion activity records

### DIFF
--- a/frontend/pages/stationary-combustion.html
+++ b/frontend/pages/stationary-combustion.html
@@ -59,6 +59,7 @@
             <th scope="col">溫室氣體排放量 (kg CO₂e)</th>
             <th scope="col">活動數據來源</th>
             <th scope="col">係數來源</th>
+            <th scope="col">活動附件</th>
             <th scope="col">備註</th>
           </tr>
         </thead>
@@ -547,6 +548,26 @@
 
 .attachment-list li {
   padding: 0.25rem 0;
+}
+
+.attachment-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.attachment-links a {
+  color: #2563eb;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.attachment-links a:hover,
+.attachment-links a:focus {
+  text-decoration: underline;
 }
 
 @media (max-width: 768px) {

--- a/frontend/public/attachments/採購單_202402.pdf
+++ b/frontend/public/attachments/採購單_202402.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 62 >>
+stream
+BT
+/F1 12 Tf
+72 100 Td
+(固定燃燒排放源活動附件範例) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000059 00000 n 
+0000000108 00000 n 
+0000000239 00000 n 
+0000000363 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+455
+%%EOF


### PR DESCRIPTION
## Summary
- add an "活動附件" column to the stationary combustion activity list and style attachment links
- enable uploading attachments and render downloadable links for each record, including data sourced from CSV
- add a sample attachment asset to back existing seed data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcc670f68883209110a1c6a1ba356f