### PR TITLE
Refine business travel and logistics data tables

### DIFF
--- a/frontend/pages/business-travel.html
+++ b/frontend/pages/business-travel.html
@@ -43,16 +43,6 @@
       <table class="data-table travel-table" aria-describedby="inventoryYearDisplay">
         <thead>
           <tr>
-            <th scope="col" class="table-action-column">
-              <button
-                id="tableAddTravelButton"
-                class="table-add-button"
-                type="button"
-                aria-label="新增活動資料"
-              >
-                新增
-              </button>
-            </th>
             <th scope="col">公司名稱</th>
             <th scope="col">據點名稱</th>
             <th scope="col">出發日期</th>
@@ -367,43 +357,6 @@
 .data-table td {
   background: #ffffff;
   color: #1f2933;
-}
-
-.table-action-column {
-  width: 96px;
-  text-align: center;
-}
-
-.table-add-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  border: 1px solid #2563eb;
-  background: #f8fafc;
-  color: #2563eb;
-  font-weight: 600;
-  font-size: 0.95rem;
-  cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.table-add-button:hover {
-  background: #2563eb;
-  color: #ffffff;
-  box-shadow: 0 6px 16px rgba(37, 99, 235, 0.25);
-}
-
-.table-add-button:focus {
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.3);
-}
-
-.table-action-cell {
-  background: #f9fafb;
-  text-align: center;
 }
 
 .data-table td.is-editable-cell {

--- a/frontend/pages/upstream-logistics-consumables.html
+++ b/frontend/pages/upstream-logistics-consumables.html
@@ -54,6 +54,7 @@
             <th scope="col">排放量 (kg CO₂e)</th>
             <th scope="col">活動數據來源</th>
             <th scope="col">排放係數來源</th>
+            <th scope="col">活動附件</th>
           </tr>
         </thead>
         <tbody id="consumablesTableBody"></tbody>
@@ -342,8 +343,16 @@
   white-space: nowrap;
 }
 
+.data-table td.is-editable-cell {
+  background: #fff9db;
+}
+
 .data-table tbody tr:hover {
   background: #f9fafb;
+}
+
+.data-table tbody tr:hover td.is-editable-cell {
+  background: #fff9db;
 }
 
 .data-table th {
@@ -516,6 +525,57 @@
   font-weight: 600;
   cursor: pointer;
   text-decoration: underline;
+}
+
+.attachment-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.attachment-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.attachment-links a {
+  color: #2563eb;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.attachment-links a:hover,
+.attachment-links a:focus {
+  text-decoration: underline;
+}
+
+.attachment-empty {
+  color: #6b7280;
+}
+
+.attachment-upload-button {
+  align-self: flex-start;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid #2563eb;
+  background: #f8fafc;
+  color: #2563eb;
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.attachment-upload-button:hover,
+.attachment-upload-button:focus {
+  background: #2563eb;
+  color: #ffffff;
+  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.25);
+  outline: none;
 }
 
 .attachment-list {

--- a/frontend/src/page-inits/business-travel.ts
+++ b/frontend/src/page-inits/business-travel.ts
@@ -151,7 +151,6 @@ export function initBusinessTravel() {
   const dropZone = document.getElementById('attachmentDropZone');
   const browseButton = document.getElementById('browseAttachmentButton');
   const addError = document.getElementById('addRecordError');
-  const tableAddButton = document.getElementById('tableAddTravelButton');
   const reasonModal = document.getElementById('returnReasonModal');
   const reasonForm = document.getElementById('returnReasonForm') as HTMLFormElement | null;
   const reasonInput = document.getElementById('returnReasonInput') as HTMLTextAreaElement | null;
@@ -175,7 +174,6 @@ export function initBusinessTravel() {
     !dropZone ||
     !browseButton ||
     !addError ||
-    !tableAddButton ||
     !reasonModal ||
     !reasonForm ||
     !reasonInput ||
@@ -198,7 +196,6 @@ export function initBusinessTravel() {
   const openAddRecordModal = () => openModal(addModal);
 
   addButton.addEventListener('click', openAddRecordModal);
-  tableAddButton.addEventListener('click', openAddRecordModal);
   addModal.querySelectorAll('[data-close-modal]').forEach((element) => {
     element.addEventListener('click', () => closeModal(addModal));
   });
@@ -502,8 +499,6 @@ export function initBusinessTravel() {
     const row = document.createElement('tr');
     row.dataset.id = record.id;
 
-    row.appendChild(createActionCell());
-
     row.appendChild(createTextCell(record.company));
 
     row.appendChild(
@@ -681,12 +676,6 @@ export function initBusinessTravel() {
     updateRow(row, record);
 
     return row;
-  }
-
-  function createActionCell() {
-    const cell = document.createElement('td');
-    cell.className = 'table-action-cell';
-    return cell;
   }
 
   function createTextCell(text: string) {


### PR DESCRIPTION
## Summary
- remove the inline "新增" column from the business travel results table so rows now begin with company data
- highlight editable cells and add an "活動附件" column to the upstream logistics consumables table with upload/download affordances
- update the logistics page initializer to track attachment objects, refresh inline uploads, and keep editable cells styled consistently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcdc77cf548320b6ab7803a40d4121