### PR TITLE
Adjust activity info cards to full width

### DIFF
--- a/frontend/pages/business-travel.html
+++ b/frontend/pages/business-travel.html
@@ -228,11 +228,13 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .info-card__row {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
   gap: 1.25rem;
   align-items: center;
 }
@@ -609,6 +611,10 @@ input:focus {
   .page-header {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .info-card__row {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .info-field--actions,

--- a/frontend/pages/fugitive-emissions.html
+++ b/frontend/pages/fugitive-emissions.html
@@ -204,11 +204,13 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .info-card__row {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
   gap: 1rem;
   align-items: center;
 }
@@ -563,6 +565,10 @@
   .page-header {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .info-card__row {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .info-field--actions {

--- a/frontend/pages/indirect-electricity.html
+++ b/frontend/pages/indirect-electricity.html
@@ -204,11 +204,13 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .info-card__row {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
   gap: 1.25rem;
   align-items: center;
 }
@@ -613,6 +615,10 @@
   .page-header {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .info-card__row {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .info-field--actions {

--- a/frontend/pages/mobile-sources.html
+++ b/frontend/pages/mobile-sources.html
@@ -213,12 +213,14 @@
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .info-card__row {
   display: grid;
   gap: 1.5rem;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
   align-items: center;
 }
 
@@ -621,11 +623,12 @@
 
 @media (max-width: 960px) {
   .info-card__row {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: minmax(0, 1fr) auto;
   }
 
   .info-field--actions {
-    justify-self: start;
+    grid-column: 1 / -1;
+    justify-self: flex-start;
   }
 
   .page-header {

--- a/frontend/pages/septic-tank.html
+++ b/frontend/pages/septic-tank.html
@@ -245,11 +245,13 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .info-card__row {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
   gap: 1.5rem;
 }
 

--- a/frontend/pages/stationary-combustion.html
+++ b/frontend/pages/stationary-combustion.html
@@ -216,11 +216,13 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .info-card__row {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
   gap: 1rem;
   align-items: center;
 }
@@ -569,6 +571,10 @@
   .page-header {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .info-card__row {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .info-field--actions {

--- a/frontend/pages/upstream-logistics-consumables.html
+++ b/frontend/pages/upstream-logistics-consumables.html
@@ -223,11 +223,13 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .info-card__row {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
   gap: 1rem;
   align-items: center;
 }
@@ -638,6 +640,10 @@
 @media (max-width: 720px) {
   .data-table {
     min-width: 720px;
+  }
+
+  .info-card__row {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .info-field--actions {

--- a/frontend/pages/upstream-office-consumables.html
+++ b/frontend/pages/upstream-office-consumables.html
@@ -223,11 +223,13 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .info-card__row {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
   gap: 1rem;
   align-items: center;
 }
@@ -637,6 +639,10 @@
 @media (max-width: 720px) {
   .data-table {
     min-width: 720px;
+  }
+
+  .info-card__row {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .info-field--actions {


### PR DESCRIPTION
## Summary
- expand the activity collection info cards to stretch the full page width and prevent action buttons from being clipped
- update responsive breakpoints so audit action controls stack cleanly on narrow viewports

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68dd3f77fedc832088fcadbde7f41122