### PR TITLE
Align stationary combustion page header controls to left

### DIFF
--- a/frontend/pages/stationary-combustion.html
+++ b/frontend/pages/stationary-combustion.html
@@ -170,9 +170,9 @@
 
 .page-header {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   align-items: flex-start;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .page-header h1 {
@@ -221,10 +221,14 @@
 }
 
 .info-card__row {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
-  gap: 1rem;
-  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  align-items: flex-start;
+}
+
+.info-field {
+  min-width: 200px;
 }
 
 .info-field dt {
@@ -240,7 +244,7 @@
 }
 
 .info-field--actions {
-  justify-self: flex-end;
+  margin-left: 0;
 }
 
 .status-badge {


### PR DESCRIPTION
## Summary
- stack the stationary combustion page header so the add data button aligns to the left with the page title
- left-align the audit status and audit action controls within the info card for better readability

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd433c91f083208a41eaae9bfd6fc0