### PR TITLE
Align activity header actions to the left

### DIFF
--- a/frontend/pages/business-travel.html
+++ b/frontend/pages/business-travel.html
@@ -179,8 +179,8 @@
 
 .page-header {
   display: flex;
+  flex-direction: column;
   align-items: flex-start;
-  justify-content: space-between;
   gap: 1rem;
 }
 
@@ -236,7 +236,8 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
   gap: 1.25rem;
-  align-items: center;
+  align-items: start;
+  justify-items: start;
 }
 
 .info-field {
@@ -260,14 +261,14 @@
 }
 
 .info-field--actions {
-  justify-self: end;
+  justify-self: start;
 }
 
 .button-group {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
-  justify-content: flex-end;
+  justify-content: flex-start;
 }
 
 .status-badge {

--- a/frontend/pages/fugitive-emissions.html
+++ b/frontend/pages/fugitive-emissions.html
@@ -156,7 +156,7 @@
 
 .page-header {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   align-items: flex-start;
   gap: 1rem;
 }
@@ -212,7 +212,8 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
   gap: 1rem;
-  align-items: center;
+  align-items: start;
+  justify-items: start;
 }
 
 .info-field dt {
@@ -228,7 +229,7 @@
 }
 
 .info-field--actions {
-  justify-self: flex-end;
+  justify-self: start;
 }
 
 .status-badge {
@@ -564,7 +565,7 @@
 @media (max-width: 768px) {
   .page-header {
     flex-direction: column;
-    align-items: stretch;
+    align-items: flex-start;
   }
 
   .info-card__row {

--- a/frontend/pages/indirect-electricity.html
+++ b/frontend/pages/indirect-electricity.html
@@ -155,8 +155,8 @@
 
 .page-header {
   display: flex;
+  flex-direction: column;
   align-items: flex-start;
-  justify-content: space-between;
   gap: 1rem;
 }
 
@@ -212,7 +212,8 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
   gap: 1.25rem;
-  align-items: center;
+  align-items: start;
+  justify-items: start;
 }
 
 .info-field {
@@ -236,14 +237,14 @@
 }
 
 .info-field--actions {
-  justify-self: end;
+  justify-self: start;
 }
 
 .button-group {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
-  justify-content: flex-end;
+  justify-content: flex-start;
 }
 
 .status-badge {

--- a/frontend/pages/mobile-sources.html
+++ b/frontend/pages/mobile-sources.html
@@ -171,9 +171,9 @@
 
 .page-header {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   align-items: flex-start;
-  gap: 1.5rem;
+  gap: 1.25rem;
 }
 
 .page-header__text h1 {
@@ -189,7 +189,7 @@
 }
 
 .primary-action {
-  align-self: center;
+  align-self: flex-start;
   border: none;
   background: linear-gradient(135deg, #2563eb, #1d4ed8);
   color: #ffffff;
@@ -221,7 +221,8 @@
   display: grid;
   gap: 1.5rem;
   grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
-  align-items: center;
+  align-items: start;
+  justify-items: start;
 }
 
 .info-field dt {
@@ -239,7 +240,7 @@
 }
 
 .info-field--actions {
-  justify-self: end;
+  justify-self: start;
 }
 
 .button-group {

--- a/frontend/pages/septic-tank.html
+++ b/frontend/pages/septic-tank.html
@@ -196,9 +196,9 @@
 
 .page-header {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   align-items: flex-start;
-  gap: 1.5rem;
+  gap: 1.25rem;
 }
 
 .page-header__text h1 {
@@ -214,7 +214,7 @@
 }
 
 .primary-action {
-  align-self: center;
+  align-self: flex-start;
   border: none;
   background: linear-gradient(135deg, #2563eb, #1d4ed8);
   color: #ffffff;
@@ -253,6 +253,8 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
   gap: 1.5rem;
+  align-items: start;
+  justify-items: start;
 }
 
 .info-field dt {

--- a/frontend/pages/upstream-logistics-consumables.html
+++ b/frontend/pages/upstream-logistics-consumables.html
@@ -178,7 +178,7 @@
 
 .page-header {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   align-items: flex-start;
   gap: 1rem;
 }
@@ -231,7 +231,8 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
   gap: 1rem;
-  align-items: center;
+  align-items: start;
+  justify-items: start;
 }
 
 .info-field dt {
@@ -250,14 +251,14 @@
 }
 
 .info-field--actions {
-  justify-self: flex-end;
+  justify-self: start;
 }
 
 .button-group {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
-  justify-content: flex-end;
+  justify-content: flex-start;
 }
 
 .info-card__message {

--- a/frontend/pages/upstream-office-consumables.html
+++ b/frontend/pages/upstream-office-consumables.html
@@ -178,7 +178,7 @@
 
 .page-header {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   align-items: flex-start;
   gap: 1rem;
 }
@@ -231,7 +231,8 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
   gap: 1rem;
-  align-items: center;
+  align-items: start;
+  justify-items: start;
 }
 
 .info-field dt {
@@ -250,14 +251,14 @@
 }
 
 .info-field--actions {
-  justify-self: flex-end;
+  justify-self: start;
 }
 
 .button-group {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
-  justify-content: flex-end;
+  justify-content: flex-start;
 }
 
 .info-card__message {


### PR DESCRIPTION
## Summary
- align the page headers so the add-data buttons sit on the left across the targeted activity collection pages
- update each info card to left-align the audit status badges and review button groups for better readability
- ensure responsive rules keep the new alignment for smaller screens on the updated pages

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd4533a6e083208ac8c3c108199e42