### PR TITLE
Fix forklift activity page rendering

### DIFF
--- a/frontend/pages/purchased-goods-services-forklift.html
+++ b/frontend/pages/purchased-goods-services-forklift.html
@@ -71,3 +71,297 @@
     </ul>
   </section>
 </section>
+
+<style>
+  .purchased-forklift-page {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    padding: 1.5rem;
+    color: #111827;
+  }
+
+  .page-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    background: #ffffff;
+    border-radius: 16px;
+    padding: 1.5rem;
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  }
+
+  .page-header__text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .page-header h1 {
+    margin: 0;
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #1f2937;
+  }
+
+  .page-header p {
+    margin: 0;
+    color: #4b5563;
+    line-height: 1.5;
+  }
+
+  .primary-action {
+    align-self: flex-start;
+    padding: 0.75rem 1.5rem;
+    border: none;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #2563eb, #1d4ed8);
+    color: #ffffff;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .primary-action:hover,
+  .primary-action:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 20px rgba(37, 99, 235, 0.2);
+  }
+
+  .primary-action:focus {
+    outline: none;
+  }
+
+  .info-card,
+  .table-card,
+  .page-hint {
+    background: #ffffff;
+    border-radius: 16px;
+    padding: 1.5rem;
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .info-card__row {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
+    gap: 1.25rem;
+    align-items: start;
+  }
+
+  .info-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .info-field dt {
+    margin: 0;
+    font-size: 0.9rem;
+    color: #6b7280;
+    font-weight: 600;
+  }
+
+  .info-field dd {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #111827;
+  }
+
+  .info-field--actions {
+    justify-self: start;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .button-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+  }
+
+  .status-badge--draft {
+    background: #fef3c7;
+    color: #92400e;
+  }
+
+  .status-badge--submitted {
+    background: #dbeafe;
+    color: #1e40af;
+  }
+
+  .status-badge--approved {
+    background: #dcfce7;
+    color: #166534;
+  }
+
+  .info-card__message {
+    margin: 0;
+    color: #374151;
+    font-size: 0.95rem;
+  }
+
+  .table-card__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .table-card__header h2 {
+    margin: 0;
+    font-size: 1.4rem;
+    color: #1f2937;
+  }
+
+  .table-card__header p {
+    margin: 0;
+    color: #6b7280;
+    font-size: 0.95rem;
+  }
+
+  .table-scroll {
+    overflow: auto;
+    border-radius: 12px;
+    border: 1px solid #e5e7eb;
+  }
+
+  .data-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 1080px;
+  }
+
+  .data-table th,
+  .data-table td {
+    padding: 0.75rem 1rem;
+    text-align: left;
+    border-bottom: 1px solid #e5e7eb;
+    vertical-align: top;
+  }
+
+  .data-table thead {
+    background: #f3f4f6;
+    color: #1f2937;
+  }
+
+  .data-table tbody tr:hover {
+    background: #f9fafb;
+  }
+
+  .table-card__empty {
+    margin: 0;
+    color: #6b7280;
+    font-size: 0.95rem;
+    text-align: center;
+  }
+
+  .page-hint h2 {
+    margin: 0;
+    font-size: 1.2rem;
+    color: #1f2937;
+  }
+
+  .page-hint ul {
+    margin: 0;
+    padding-left: 1.2rem;
+    color: #4b5563;
+  }
+
+  .page-hint li {
+    line-height: 1.6;
+  }
+
+  .attachment-links {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .attachment-links a {
+    color: #2563eb;
+    text-decoration: none;
+    font-weight: 600;
+  }
+
+  .attachment-links a:hover,
+  .attachment-links a:focus {
+    text-decoration: underline;
+  }
+
+  .primary-button {
+    padding: 0.55rem 1.2rem;
+    border-radius: 10px;
+    border: none;
+    background: #2563eb;
+    color: #ffffff;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease;
+  }
+
+  .primary-button:hover,
+  .primary-button:focus {
+    background: #1d4ed8;
+  }
+
+  .secondary-button {
+    padding: 0.55rem 1.2rem;
+    border-radius: 10px;
+    border: 1px solid #cbd5f5;
+    background: #eef2ff;
+    color: #4338ca;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease;
+  }
+
+  .secondary-button:hover,
+  .secondary-button:focus {
+    background: #e0e7ff;
+    border-color: #a5b4fc;
+  }
+
+  @media (max-width: 960px) {
+    .info-card__row {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .page-header {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .primary-action {
+      width: 100%;
+      justify-content: center;
+    }
+  }
+</style>

--- a/frontend/public/data/purchased-forklift-activities.csv
+++ b/frontend/public/data/purchased-forklift-activities.csv
@@ -1,0 +1,4 @@
+site_name,depot_name,model,usage,purchase_date,energy_type,annual_usage,usage_unit,emission_factor,emission_factor_unit,gwp,emissions,data_source,factor_source,attachments,notes
+北區物流樞紐,新莊自動倉,TOYOTA 8FBE20,高架儲位揀貨,2024-01-15,電力,12500,kWh,0.495,kg CO2e/kWh,1,6187.5,採購系統匯出,台電公告排放係數(2024),採購單_202402.pdf|倉儲堆高機採購單,新增自動倉專用電動堆高機
+北區物流樞紐,新莊自動倉,TOYOTA 8FBE25,月台裝卸,2023-11-30,柴油,4200,公升,2.68,kg CO2e/公升,1,11256,調度單管理系統,能源局固定燃燒排放係數(2024),調度單_202406.pdf|柴油補給調度單,租賃車輛汰換為自有堆高機
+南區配送中心,高雄港冷鏈倉,LINDE E16,冷鏈出貨,2024-03-10,電力,9800,kWh,0.495,kg CO2e/kWh,1,4851,倉儲能源抄表,台電公告排放係數(2024),溫度紀錄表_202406.xlsx|冷鏈倉溫度紀錄,冷鏈倉儲區專用設備

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -477,6 +477,13 @@ import('./page-inits/fugitive-emissions')
       (pageInitializers['pages/fugitive-emissions.html'] = m.initFugitiveEmissions)
   )
   .catch(() => {});
+import('./page-inits/purchased-goods-services-forklift')
+  .then(
+    (m) =>
+      (pageInitializers['pages/purchased-goods-services-forklift.html'] =
+        m.initPurchasedGoodsServicesForklift)
+  )
+  .catch(() => {});
 import('./page-inits/septic-tank')
   .then((m) => (pageInitializers['pages/septic-tank.html'] = m.initSepticTank))
   .catch(() => {});

--- a/frontend/src/page-inits/purchased-goods-services-forklift.ts
+++ b/frontend/src/page-inits/purchased-goods-services-forklift.ts
@@ -1,0 +1,302 @@
+import { loadCsvRows, type CsvRow } from '../utils/csv-loader';
+
+type AuditStatus = 'Draft' | 'Submitted' | 'Approved';
+
+type Attachment = { name: string; url: string };
+
+type ForkliftRecord = {
+  siteName: string;
+  depotName: string;
+  model: string;
+  usage: string;
+  purchaseDate: string;
+  energyType: string;
+  annualUsage: number;
+  usageUnit: string;
+  emissionFactor: number;
+  emissionFactorUnit: string;
+  gwp: number;
+  emissions: number;
+  dataSource: string;
+  factorSource: string;
+  attachments: Attachment[];
+  notes?: string;
+};
+
+const INVENTORY_YEAR = '2024';
+const DATA_PATH = `${import.meta.env.BASE_URL}data/purchased-forklift-activities.csv`;
+const ATTACHMENT_BASE_PATH = `${import.meta.env.BASE_URL}attachments/`;
+
+const STATUS_DISPLAY: Record<AuditStatus, { label: string; badgeClass: string }> = {
+  Draft: { label: '草稿', badgeClass: 'status-badge--draft' },
+  Submitted: { label: '已送審', badgeClass: 'status-badge--submitted' },
+  Approved: { label: '審核通過', badgeClass: 'status-badge--approved' },
+};
+
+export function initPurchasedGoodsServicesForklift() {
+  const inventoryYearEl = document.getElementById('forkliftInventoryYear');
+  const statusBadge = document.getElementById('forkliftAuditStatus');
+  const actionContainer = document.getElementById('forkliftAuditActions');
+  const statusMessage = document.getElementById('forkliftAuditMessage');
+  const tableBody = document.getElementById('forkliftTableBody');
+  const emptyMessage = document.getElementById('forkliftEmptyMessage');
+
+  if (
+    !inventoryYearEl ||
+    !statusBadge ||
+    !actionContainer ||
+    !statusMessage ||
+    !tableBody ||
+    !emptyMessage
+  ) {
+    return;
+  }
+
+  inventoryYearEl.textContent = `${INVENTORY_YEAR} 年`;
+
+  let currentStatus: AuditStatus = 'Draft';
+  let statusTimer: number | undefined;
+
+  updateStatusUI();
+  loadForkliftRecords();
+
+  function loadForkliftRecords() {
+    loadCsvRows(DATA_PATH)
+      .then((rows) => rows.map(parseRecord).filter((record): record is ForkliftRecord => record !== null))
+      .then((records) => {
+        renderTable(records);
+      })
+      .catch((error) => {
+        console.error('Failed to load forklift records from CSV.', error);
+        tableBody.innerHTML = '';
+        emptyMessage.hidden = false;
+        emptyMessage.textContent = '無法載入活動資料，請稍後再試。';
+      });
+  }
+
+  function parseRecord(row: CsvRow): ForkliftRecord | null {
+    const siteName = row.site_name?.trim();
+    const depotName = row.depot_name?.trim();
+    const model = row.model?.trim();
+    const usage = row.usage?.trim();
+    const purchaseDate = row.purchase_date?.trim();
+    const energyType = row.energy_type?.trim();
+    const usageText = row.annual_usage?.trim();
+    const usageUnit = row.usage_unit?.trim();
+    const emissionFactorText = row.emission_factor?.trim();
+    const emissionFactorUnit = row.emission_factor_unit?.trim();
+    const gwpText = row.gwp?.trim();
+    const emissionsText = row.emissions?.trim();
+    const dataSource = row.data_source?.trim();
+    const factorSource = row.factor_source?.trim();
+    const attachmentsText = row.attachments?.trim();
+    const notes = row.notes?.trim();
+
+    if (
+      !siteName ||
+      !depotName ||
+      !model ||
+      !usage ||
+      !purchaseDate ||
+      !energyType ||
+      !usageText ||
+      !usageUnit ||
+      !emissionFactorText ||
+      !emissionFactorUnit ||
+      !gwpText ||
+      !emissionsText ||
+      !dataSource ||
+      !factorSource
+    ) {
+      return null;
+    }
+
+    const annualUsage = Number.parseFloat(usageText.replace(/,/g, ''));
+    const emissionFactor = Number.parseFloat(emissionFactorText.replace(/,/g, ''));
+    const gwp = Number.parseFloat(gwpText.replace(/,/g, ''));
+    const emissions = Number.parseFloat(emissionsText.replace(/,/g, ''));
+
+    if (![annualUsage, emissionFactor, gwp, emissions].every((value) => Number.isFinite(value))) {
+      return null;
+    }
+
+    return {
+      siteName,
+      depotName,
+      model,
+      usage,
+      purchaseDate,
+      energyType,
+      annualUsage,
+      usageUnit,
+      emissionFactor,
+      emissionFactorUnit,
+      gwp,
+      emissions,
+      dataSource,
+      factorSource,
+      attachments: parseAttachments(attachmentsText),
+      notes,
+    };
+  }
+
+  function parseAttachments(value?: string): Attachment[] {
+    if (!value) {
+      return [];
+    }
+
+    return value
+      .split(';')
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0)
+      .map((entry) => {
+        const [fileName, label] = entry.split('|').map((part) => part.trim());
+        const name = label || fileName;
+        return {
+          name,
+          url: `${ATTACHMENT_BASE_PATH}${fileName}`,
+        };
+      })
+      .filter((attachment) => Boolean(attachment.url));
+  }
+
+  function renderTable(records: ForkliftRecord[]) {
+    tableBody.innerHTML = '';
+
+    if (records.length === 0) {
+      emptyMessage.hidden = false;
+      emptyMessage.textContent = '目前尚無活動資料，請新增資料。';
+      return;
+    }
+
+    emptyMessage.hidden = true;
+
+    const fragment = document.createDocumentFragment();
+
+    records.forEach((record) => {
+      const row = document.createElement('tr');
+      row.appendChild(createCell(record.siteName));
+      row.appendChild(createCell(record.depotName));
+      row.appendChild(createCell(record.model));
+      row.appendChild(createCell(record.usage));
+      row.appendChild(createCell(formatDate(record.purchaseDate)));
+      row.appendChild(createCell(record.energyType));
+      row.appendChild(createCell(formatNumber(record.annualUsage, 0, 0)));
+      row.appendChild(createCell(record.usageUnit));
+      row.appendChild(createCell(formatNumber(record.emissionFactor, 0, 3)));
+      row.appendChild(createCell(record.emissionFactorUnit));
+      row.appendChild(createCell(formatNumber(record.gwp, 0, 0)));
+      row.appendChild(createCell(formatNumber(record.emissions, 0, 2)));
+      row.appendChild(createCell(record.dataSource));
+      row.appendChild(createCell(record.factorSource));
+      row.appendChild(createAttachmentCell(record.attachments));
+      row.appendChild(createCell(record.notes || '—'));
+      fragment.appendChild(row);
+    });
+
+    tableBody.appendChild(fragment);
+  }
+
+  function createCell(text: string): HTMLTableCellElement {
+    const cell = document.createElement('td');
+    cell.textContent = text;
+    return cell;
+  }
+
+  function createAttachmentCell(attachments: Attachment[]): HTMLTableCellElement {
+    const cell = document.createElement('td');
+
+    if (attachments.length === 0) {
+      cell.textContent = '—';
+      return cell;
+    }
+
+    const list = document.createElement('ul');
+    list.className = 'attachment-links';
+
+    attachments.forEach(({ name, url }) => {
+      const item = document.createElement('li');
+      const link = document.createElement('a');
+      link.href = url;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.textContent = name;
+      link.download = name;
+      item.appendChild(link);
+      list.appendChild(item);
+    });
+
+    cell.appendChild(list);
+    return cell;
+  }
+
+  function formatNumber(value: number, minimumFractionDigits: number, maximumFractionDigits: number): string {
+    return value.toLocaleString('zh-TW', {
+      minimumFractionDigits,
+      maximumFractionDigits,
+    });
+  }
+
+  function formatDate(value: string): string {
+    return value.replace(/-/g, '/');
+  }
+
+  function updateStatusUI() {
+    const config = STATUS_DISPLAY[currentStatus];
+    statusBadge.textContent = config.label;
+    statusBadge.className = `status-badge ${config.badgeClass}`;
+
+    actionContainer.innerHTML = '';
+
+    if (currentStatus === 'Draft') {
+      actionContainer.appendChild(
+        createActionButton('送審', () => {
+          currentStatus = 'Submitted';
+          showStatusMessage('資料已送出審核，等待審核結果。');
+          updateStatusUI();
+        })
+      );
+    } else if (currentStatus === 'Submitted') {
+      actionContainer.appendChild(
+        createActionButton(
+          '退回',
+          () => {
+            currentStatus = 'Draft';
+            showStatusMessage('審核人員已退回資料，請修正後再送審。');
+            updateStatusUI();
+          },
+          true
+        )
+      );
+
+      actionContainer.appendChild(
+        createActionButton('審核通過', () => {
+          currentStatus = 'Approved';
+          showStatusMessage('資料已完成審核。');
+          updateStatusUI();
+        })
+      );
+    }
+  }
+
+  function createActionButton(label: string, onClick: () => void, isSecondary = false): HTMLButtonElement {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = isSecondary ? 'secondary-button' : 'primary-button';
+    button.textContent = label;
+    button.addEventListener('click', onClick);
+    return button;
+  }
+
+  function showStatusMessage(message: string) {
+    statusMessage.textContent = message;
+
+    if (statusTimer) {
+      window.clearTimeout(statusTimer);
+    }
+
+    statusTimer = window.setTimeout(() => {
+      statusMessage.textContent = '';
+    }, 5000);
+  }
+}


### PR DESCRIPTION
## Summary
- add a forklift activity CSV seed and page initializer to render the table and audit controls
- register the initializer in the SPA shell and apply dedicated styling so the page matches other activity pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd4b73e9ec8320a4502b840cac4157