### PR TITLE
Add emission source instance management interface

### DIFF
--- a/frontend/pages/emission-source-instances.html
+++ b/frontend/pages/emission-source-instances.html
@@ -1,4 +1,497 @@
-<section class="page-content">
-  <h1>排放源實例管理</h1>
-  <p>建立與維護各排放源實際設備或活動的詳細資料。</p>
+<section
+  class="page-content emission-source-instances"
+  aria-labelledby="emissionSourceInstancesTitle"
+>
+  <header class="page-header">
+    <h1 id="emissionSourceInstancesTitle">排放源實例管理</h1>
+    <p>
+      針對盤查年度與站點已挑選之排放源類型，建立對應設備或活動的實例資料，協助後續盤點與維護。
+    </p>
+  </header>
+
+  <article class="filter-card" aria-label="篩選條件">
+    <form id="instanceFilterForm" class="filter-form" novalidate>
+      <div class="filter-grid">
+        <label class="filter-field" for="filterYearSelect">
+          <span class="field-label">盤查年度</span>
+          <select id="filterYearSelect" name="year" required>
+            <option value="">請選擇盤查年度</option>
+          </select>
+        </label>
+        <label class="filter-field" for="filterCountrySelect">
+          <span class="field-label">國家</span>
+          <select id="filterCountrySelect" name="country" required>
+            <option value="">請選擇國家</option>
+          </select>
+        </label>
+        <label class="filter-field" for="filterRegionSelect">
+          <span class="field-label">區域</span>
+          <select id="filterRegionSelect" name="region" required disabled>
+            <option value="">請先選擇國家</option>
+          </select>
+        </label>
+        <label class="filter-field" for="filterSiteSelect">
+          <span class="field-label">站點</span>
+          <select id="filterSiteSelect" name="site" required disabled>
+            <option value="">請先選擇區域</option>
+          </select>
+        </label>
+        <label class="filter-field" for="filterSourceTypeSelect">
+          <span class="field-label">排放源類型</span>
+          <select id="filterSourceTypeSelect" name="sourceType" required>
+            <option value="">請選擇排放源類型</option>
+          </select>
+        </label>
+      </div>
+      <div class="filter-actions">
+        <p id="filterErrorMessage" class="filter-error" role="alert" aria-live="assertive"></p>
+        <div class="filter-buttons">
+          <button type="submit" class="primary-action">查詢</button>
+          <button
+            type="button"
+            id="openInstanceModal"
+            class="secondary-action"
+            disabled
+          >
+            新增
+          </button>
+        </div>
+      </div>
+    </form>
+  </article>
+
+  <article class="table-card" aria-labelledby="instanceTableTitle">
+    <header class="table-card__header">
+      <div>
+        <h2 id="instanceTableTitle">排放源實例列表</h2>
+        <p id="selectionSummary" class="selection-summary">
+          請先設定篩選條件並點擊「查詢」以載入排放源實例。
+        </p>
+      </div>
+    </header>
+    <div class="table-scroll" role="region" aria-labelledby="instanceTableTitle">
+      <table class="data-table" aria-describedby="selectionSummary">
+        <thead>
+          <tr>
+            <th scope="col">據點名稱</th>
+            <th scope="col">排放源類型</th>
+            <th scope="col">實例名稱</th>
+            <th scope="col">系統編號</th>
+            <th scope="col">財產編號</th>
+            <th scope="col">啟用日</th>
+            <th scope="col">備註</th>
+            <th scope="col">維護人</th>
+          </tr>
+        </thead>
+        <tbody id="instanceTableBody"></tbody>
+      </table>
+    </div>
+    <p id="instancesEmptyMessage" class="table-empty" hidden>目前尚無符合條件的排放源實例。</p>
+    <p id="instanceStatusMessage" class="table-status" role="status" aria-live="polite"></p>
+  </article>
+
+  <div id="createInstanceModal" class="modal" aria-hidden="true">
+    <div class="modal__overlay" data-close-modal></div>
+    <div
+      class="modal__dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="createInstanceModalTitle"
+    >
+      <header class="modal__header">
+        <h2 id="createInstanceModalTitle">新增排放源實例</h2>
+        <button
+          class="modal__close"
+          type="button"
+          data-close-modal
+          aria-label="關閉新增視窗"
+        ></button>
+      </header>
+      <form id="createInstanceForm" class="modal__body" novalidate>
+        <div class="form-grid">
+          <label class="form-field">
+            <span class="form-label">據點名稱</span>
+            <select id="modalFacilitySelect" name="facility" required></select>
+          </label>
+          <label class="form-field">
+            <span class="form-label">排放源類型</span>
+            <select id="modalSourceTypeSelect" name="sourceType" required></select>
+          </label>
+          <label class="form-field">
+            <span class="form-label">實例名稱</span>
+            <input id="modalInstanceName" name="instanceName" type="text" required />
+          </label>
+          <label class="form-field">
+            <span class="form-label">系統編號</span>
+            <input id="modalSystemNumber" name="systemNumber" type="text" required />
+          </label>
+          <label class="form-field">
+            <span class="form-label">財產編號</span>
+            <input id="modalAssetNumber" name="assetNumber" type="text" required />
+          </label>
+          <label class="form-field">
+            <span class="form-label">啟用日</span>
+            <input id="modalActivationDate" name="activationDate" type="date" required />
+          </label>
+          <label class="form-field form-field--span">
+            <span class="form-label">備註 (選填)</span>
+            <textarea
+              id="modalNotes"
+              name="notes"
+              rows="2"
+              placeholder="可輸入品牌、型號、引擎、容量等資訊"
+            ></textarea>
+          </label>
+          <label class="form-field">
+            <span class="form-label">維護人</span>
+            <input id="modalMaintainer" name="maintainer" type="text" required />
+          </label>
+        </div>
+        <p id="modalErrorMessage" class="form-error" role="alert"></p>
+        <footer class="modal__footer">
+          <button class="secondary-button" type="button" data-close-modal>取消</button>
+          <button class="primary-button" type="submit">儲存</button>
+        </footer>
+      </form>
+    </div>
+  </div>
 </section>
+
+<style>
+  .emission-source-instances {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    color: #1f2937;
+  }
+
+  .emission-source-instances .page-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .emission-source-instances .page-header h1 {
+    margin: 0;
+    font-size: 2rem;
+    color: #111827;
+  }
+
+  .emission-source-instances .page-header p {
+    margin: 0;
+    line-height: 1.6;
+    color: #4b5563;
+  }
+
+  .filter-card,
+  .table-card {
+    background-color: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 14px;
+    padding: 1.5rem;
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.06);
+  }
+
+  .filter-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  .filter-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+  }
+
+  .filter-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .field-label {
+    font-weight: 600;
+    color: #374151;
+  }
+
+  select,
+  input[type='text'],
+  textarea,
+  input[type='date'] {
+    width: 100%;
+    padding: 0.6rem 0.75rem;
+    border-radius: 10px;
+    border: 1px solid #d1d5db;
+    background-color: #ffffff;
+    font-size: 1rem;
+    color: #1f2937;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  select:focus,
+  input[type='text']:focus,
+  textarea:focus,
+  input[type='date']:focus {
+    outline: none;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+  }
+
+  textarea {
+    resize: vertical;
+    min-height: 80px;
+  }
+
+  .filter-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .filter-error {
+    margin: 0;
+    min-height: 1.25rem;
+    color: #dc2626;
+  }
+
+  .filter-buttons {
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  .primary-action,
+  .primary-button {
+    border: none;
+    border-radius: 10px;
+    padding: 0.65rem 1.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #ffffff;
+    background: linear-gradient(135deg, #2563eb, #1d4ed8);
+    cursor: pointer;
+    box-shadow: 0 12px 20px rgba(37, 99, 235, 0.18);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .primary-action:hover,
+  .primary-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 14px 26px rgba(37, 99, 235, 0.24);
+  }
+
+  .primary-action:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+    box-shadow: none;
+  }
+
+  .secondary-action,
+  .secondary-button {
+    border: 1px solid #cbd5f5;
+    border-radius: 10px;
+    padding: 0.65rem 1.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #1d4ed8;
+    background: #f3f4ff;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
+  }
+
+  .secondary-action:hover,
+  .secondary-button:hover {
+    background-color: #e0e7ff;
+  }
+
+  .secondary-action:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  .table-card {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .table-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .table-card__header h2 {
+    margin: 0;
+    font-size: 1.4rem;
+    color: #111827;
+  }
+
+  .selection-summary {
+    margin: 0.35rem 0 0;
+    color: #4b5563;
+  }
+
+  .table-scroll {
+    overflow-x: auto;
+  }
+
+  .data-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 720px;
+  }
+
+  .data-table th,
+  .data-table td {
+    padding: 0.75rem 0.85rem;
+    border-bottom: 1px solid #e5e7eb;
+    text-align: left;
+    vertical-align: top;
+    line-height: 1.5;
+  }
+
+  .data-table thead th {
+    background-color: #f3f4f6;
+    font-weight: 600;
+    color: #1f2937;
+  }
+
+  .table-empty {
+    margin: 0;
+    color: #9ca3af;
+  }
+
+  .table-status {
+    margin: 0;
+    color: #2563eb;
+    min-height: 1.25rem;
+  }
+
+  .modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    z-index: 30;
+  }
+
+  .modal.is-open {
+    display: flex;
+  }
+
+  .modal__overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+  }
+
+  .modal__dialog {
+    position: relative;
+    width: min(640px, 92vw);
+    background: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 28px 60px rgba(15, 23, 42, 0.35);
+    overflow: hidden;
+  }
+
+  .modal__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.25rem 1.5rem 0;
+    gap: 1rem;
+  }
+
+  .modal__header h2 {
+    margin: 0;
+    font-size: 1.35rem;
+    color: #111827;
+  }
+
+  .modal__close {
+    position: relative;
+    width: 40px;
+    height: 40px;
+    border: none;
+    border-radius: 50%;
+    background: #f3f4f6;
+    cursor: pointer;
+  }
+
+  .modal__close::before,
+  .modal__close::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 16px;
+    height: 2px;
+    background: #4b5563;
+  }
+
+  .modal__close::before {
+    transform: translate(-50%, -50%) rotate(45deg);
+  }
+
+  .modal__close::after {
+    transform: translate(-50%, -50%) rotate(-45deg);
+  }
+
+  .modal__body {
+    padding: 1.25rem 1.5rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  .form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+  }
+
+  .form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+  }
+
+  .form-field--span {
+    grid-column: 1 / -1;
+  }
+
+  .form-label {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #374151;
+  }
+
+  .form-error {
+    margin: 0;
+    color: #dc2626;
+    min-height: 1.2rem;
+  }
+
+  .modal__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    padding-top: 0.75rem;
+  }
+
+  @media (max-width: 768px) {
+    .data-table {
+      min-width: 640px;
+    }
+
+    .modal__dialog {
+      width: min(92vw, 560px);
+    }
+  }
+</style>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -427,6 +427,13 @@ import('./page-inits/emission-source-site-association')
         m.initEmissionSourceSiteAssociation)
   )
   .catch(() => {});
+import('./page-inits/emission-source-instances')
+  .then(
+    (m) =>
+      (pageInitializers['pages/emission-source-instances.html'] =
+        m.initEmissionSourceInstances)
+  )
+  .catch(() => {});
 import('./page-inits/upstream-office-consumables')
   .then(
     (m) =>

--- a/frontend/src/page-inits/emission-source-instances.ts
+++ b/frontend/src/page-inits/emission-source-instances.ts
@@ -1,0 +1,578 @@
+const INVENTORY_YEARS = ['2023', '2024', '2025'];
+
+const SITE_STRUCTURE = [
+  {
+    country: '台灣',
+    regions: [
+      {
+        name: '北部區域',
+        stations: [
+          { name: '台北總部', facilities: ['台北總部大樓', '內湖資料中心'] },
+          { name: '松山辦公室', facilities: ['松山辦公室'] },
+        ],
+      },
+      {
+        name: '中部區域',
+        stations: [
+          { name: '台中營運處', facilities: ['台中營運處'] },
+        ],
+      },
+      {
+        name: '南部區域',
+        stations: [
+          { name: '高雄營運中心', facilities: ['高雄物流倉庫', '高雄備援機房'] },
+        ],
+      },
+    ],
+  },
+  {
+    country: '日本',
+    regions: [
+      {
+        name: '關東區域',
+        stations: [
+          { name: '東京辦公室', facilities: ['東京辦公室'] },
+          { name: '橫濱倉儲中心', facilities: ['橫濱倉儲中心 A 棟', '橫濱倉儲中心 B 棟'] },
+        ],
+      },
+    ],
+  },
+];
+
+const SOURCE_TYPES = [
+  { id: '1.1', name: '固定燃燒排放源 (發電機)' },
+  { id: '1.2', name: '移動排放源 (公務車)' },
+  { id: '1.4A', name: '逸散性排放 (飲水機)' },
+  { id: '2.1', name: '輸入電力的間接排放 (辦公室用電)' },
+  { id: '3.1A', name: '上游運輸物流經常耗材' },
+  { id: '3.3L', name: '物流運輸排放 (陸運)' },
+];
+
+type InstanceRecord = {
+  id: string;
+  year: string;
+  country: string;
+  region: string;
+  site: string;
+  facility: string;
+  sourceTypeId: string;
+  sourceTypeName: string;
+  instanceName: string;
+  systemNumber: string;
+  assetNumber: string;
+  activationDate: string;
+  notes?: string;
+  maintainer: string;
+};
+
+type FilterSelection = {
+  year: string;
+  country: string;
+  region: string;
+  site: string;
+  sourceTypeId: string;
+};
+
+type Option = { value: string; label: string };
+
+type StationConfig = { name: string; facilities: string[] };
+
+type RegionConfig = { name: string; stations: StationConfig[] };
+
+type CountryConfig = { country: string; regions: RegionConfig[] };
+
+const INITIAL_INSTANCES: InstanceRecord[] = [
+  {
+    id: 'taipei-generator-1',
+    year: '2024',
+    country: '台灣',
+    region: '北部區域',
+    site: '台北總部',
+    facility: '台北總部大樓',
+    sourceTypeId: '1.1',
+    sourceTypeName: '固定燃燒排放源 (發電機)',
+    instanceName: 'A 棟緊急發電機',
+    systemNumber: 'GEN-TPE-001',
+    assetNumber: 'AST-2024-015',
+    activationDate: '2023-03-15',
+    notes: '品牌：CAT / 型號：C27 / 容量：750kW',
+    maintainer: '王大同',
+  },
+  {
+    id: 'taipei-ev-fleet',
+    year: '2024',
+    country: '台灣',
+    region: '北部區域',
+    site: '台北總部',
+    facility: '內湖資料中心',
+    sourceTypeId: '1.2',
+    sourceTypeName: '移動排放源 (公務車)',
+    instanceName: '資料中心派車 A01',
+    systemNumber: 'VEH-TPE-301',
+    assetNumber: 'AST-2022-088',
+    activationDate: '2022-07-01',
+    notes: '油種：柴油 / 排氣量：3.0L',
+    maintainer: '陳雅惠',
+  },
+  {
+    id: 'kaohsiung-generator',
+    year: '2023',
+    country: '台灣',
+    region: '南部區域',
+    site: '高雄營運中心',
+    facility: '高雄物流倉庫',
+    sourceTypeId: '1.1',
+    sourceTypeName: '固定燃燒排放源 (發電機)',
+    instanceName: '倉庫備援發電機',
+    systemNumber: 'GEN-KHH-002',
+    assetNumber: 'AST-2021-042',
+    activationDate: '2021-11-20',
+    notes: '品牌：Kohler / 容量：550kW',
+    maintainer: '許智彥',
+  },
+  {
+    id: 'tokyo-electricity',
+    year: '2024',
+    country: '日本',
+    region: '關東區域',
+    site: '東京辦公室',
+    facility: '東京辦公室',
+    sourceTypeId: '2.1',
+    sourceTypeName: '輸入電力的間接排放 (辦公室用電)',
+    instanceName: '東京辦公室用電',
+    systemNumber: 'ELE-TYO-101',
+    assetNumber: 'AST-2023-115',
+    activationDate: '2023-01-01',
+    notes: '契約容量：120kW / 合約編號：TYO-EL-2023',
+    maintainer: '佐藤花奈',
+  },
+  {
+    id: 'yokohama-logistics',
+    year: '2025',
+    country: '日本',
+    region: '關東區域',
+    site: '橫濱倉儲中心',
+    facility: '橫濱倉儲中心 A 棟',
+    sourceTypeId: '3.3L',
+    sourceTypeName: '物流運輸排放 (陸運)',
+    instanceName: '橫濱出貨物流車隊',
+    systemNumber: 'LOG-YOK-007',
+    assetNumber: 'AST-2024-233',
+    activationDate: '2024-09-15',
+    notes: '合作物流商：GreenMove',
+    maintainer: '山口裕太',
+  },
+];
+
+function populateSelect(select: HTMLSelectElement, options: Option[], placeholder?: string) {
+  const previousValue = select.value;
+  select.innerHTML = '';
+
+  if (placeholder) {
+    const placeholderOption = document.createElement('option');
+    placeholderOption.value = '';
+    placeholderOption.textContent = placeholder;
+    select.appendChild(placeholderOption);
+  }
+
+  options.forEach((option) => {
+    const optionEl = document.createElement('option');
+    optionEl.value = option.value;
+    optionEl.textContent = option.label;
+    select.appendChild(optionEl);
+  });
+
+  if (options.some((option) => option.value === previousValue)) {
+    select.value = previousValue;
+  } else if (!placeholder && options.length) {
+    select.value = options[0]?.value || '';
+  } else {
+    select.value = '';
+  }
+
+  if (placeholder) {
+    select.disabled = options.length === 0;
+  } else {
+    select.disabled = false;
+  }
+}
+
+function findCountryConfig(country: string): CountryConfig | undefined {
+  return SITE_STRUCTURE.find((item) => item.country === country);
+}
+
+function findRegionConfig(country: string, region: string): RegionConfig | undefined {
+  return findCountryConfig(country)?.regions.find((item) => item.name === region);
+}
+
+function findStationConfig(country: string, region: string, site: string): StationConfig | undefined {
+  return findRegionConfig(country, region)?.stations.find((item) => item.name === site);
+}
+
+function getFacilities(country: string, region: string, site: string): string[] {
+  const station = findStationConfig(country, region, site);
+  if (!station) {
+    return site ? [site] : [];
+  }
+
+  return station.facilities.length ? station.facilities : [station.name];
+}
+
+function formatSummary(selection: FilterSelection) {
+  return `盤查年度 ${selection.year} · ${selection.country} / ${selection.region} / ${selection.site} · 排放源 ${selection.sourceTypeId}`;
+}
+
+function filterInstances(records: InstanceRecord[], selection: FilterSelection) {
+  return records.filter(
+    (record) =>
+      record.year === selection.year &&
+      record.country === selection.country &&
+      record.region === selection.region &&
+      record.site === selection.site &&
+      record.sourceTypeId === selection.sourceTypeId
+  );
+}
+
+function createTableRow(record: InstanceRecord) {
+  const tr = document.createElement('tr');
+
+  const cells: (keyof InstanceRecord | 'notes')[] = [
+    'facility',
+    'sourceTypeName',
+    'instanceName',
+    'systemNumber',
+    'assetNumber',
+    'activationDate',
+    'notes',
+    'maintainer',
+  ];
+
+  cells.forEach((key) => {
+    const td = document.createElement('td');
+    const value = record[key as keyof InstanceRecord];
+    td.textContent = value ? String(value) : '—';
+    tr.appendChild(td);
+  });
+
+  return tr;
+}
+
+export function initEmissionSourceInstances() {
+  const form = document.getElementById('instanceFilterForm') as HTMLFormElement | null;
+  const yearSelect = document.getElementById('filterYearSelect') as HTMLSelectElement | null;
+  const countrySelect = document.getElementById('filterCountrySelect') as HTMLSelectElement | null;
+  const regionSelect = document.getElementById('filterRegionSelect') as HTMLSelectElement | null;
+  const siteSelect = document.getElementById('filterSiteSelect') as HTMLSelectElement | null;
+  const sourceTypeSelect = document.getElementById('filterSourceTypeSelect') as HTMLSelectElement | null;
+  const errorMessage = document.getElementById('filterErrorMessage');
+  const summaryEl = document.getElementById('selectionSummary');
+  const tableBody = document.getElementById('instanceTableBody');
+  const emptyMessage = document.getElementById('instancesEmptyMessage');
+  const statusMessage = document.getElementById('instanceStatusMessage');
+  const addButton = document.getElementById('openInstanceModal') as HTMLButtonElement | null;
+  const modal = document.getElementById('createInstanceModal') as HTMLDivElement | null;
+  const modalForm = document.getElementById('createInstanceForm') as HTMLFormElement | null;
+  const modalFacilitySelect = document.getElementById('modalFacilitySelect') as HTMLSelectElement | null;
+  const modalSourceTypeSelect = document.getElementById('modalSourceTypeSelect') as HTMLSelectElement | null;
+  const modalError = document.getElementById('modalErrorMessage');
+  const modalCloseButtons = modal?.querySelectorAll<HTMLElement>('[data-close-modal]');
+  const modalOverlay = modal?.querySelector('.modal__overlay') as HTMLElement | null;
+
+  if (
+    !form ||
+    !yearSelect ||
+    !countrySelect ||
+    !regionSelect ||
+    !siteSelect ||
+    !sourceTypeSelect ||
+    !summaryEl ||
+    !tableBody ||
+    !emptyMessage ||
+    !statusMessage ||
+    !addButton ||
+    !modal ||
+    !modalForm ||
+    !modalFacilitySelect ||
+    !modalSourceTypeSelect ||
+    !modalError ||
+    !modalCloseButtons ||
+    !modalOverlay
+  ) {
+    return;
+  }
+
+  let records: InstanceRecord[] = [...INITIAL_INSTANCES];
+  let currentSelection: FilterSelection | undefined;
+  let facilitiesForModal: string[] = [];
+
+  populateSelect(
+    yearSelect,
+    INVENTORY_YEARS.map((year) => ({ value: year, label: `${year} 年` })),
+    '請選擇盤查年度'
+  );
+
+  populateSelect(
+    countrySelect,
+    SITE_STRUCTURE.map((item) => ({ value: item.country, label: item.country })),
+    '請選擇國家'
+  );
+
+  populateSelect(
+    sourceTypeSelect,
+    SOURCE_TYPES.map((type) => ({ value: type.id, label: `${type.id} ${type.name}` })),
+    '請選擇排放源類型'
+  );
+
+  const modalTypeOptions = SOURCE_TYPES.map((type) => ({
+    value: type.id,
+    label: `${type.id} ${type.name}`,
+  }));
+
+  function clearError() {
+    errorMessage.textContent = '';
+  }
+
+  function setError(text: string) {
+    errorMessage.textContent = text;
+  }
+
+  function clearStatus() {
+    statusMessage.textContent = '';
+  }
+
+  function setStatus(text: string) {
+    statusMessage.textContent = text;
+    window.setTimeout(() => {
+      if (statusMessage.textContent === text) {
+        statusMessage.textContent = '';
+      }
+    }, 4000);
+  }
+
+  function updateRegions() {
+    const country = countrySelect.value;
+    const countryConfig = findCountryConfig(country);
+    const options = countryConfig
+      ? countryConfig.regions.map((region) => ({ value: region.name, label: region.name }))
+      : [];
+    populateSelect(regionSelect, options, country ? '請選擇區域' : '請先選擇國家');
+    if (!country) {
+      populateSelect(siteSelect, [], '請先選擇區域');
+    }
+    updateAddButtonState();
+  }
+
+  function updateSites() {
+    const country = countrySelect.value;
+    const region = regionSelect.value;
+    const regionConfig = findRegionConfig(country, region);
+    const options = regionConfig
+      ? regionConfig.stations.map((station) => ({ value: station.name, label: station.name }))
+      : [];
+    populateSelect(siteSelect, options, region ? '請選擇站點' : '請先選擇區域');
+    updateAddButtonState();
+  }
+
+  function updateAddButtonState() {
+    const readyForModal =
+      !!yearSelect.value &&
+      !!countrySelect.value &&
+      !!regionSelect.value &&
+      !!siteSelect.value &&
+      !!sourceTypeSelect.value;
+    addButton.disabled = !readyForModal;
+  }
+
+  function renderTable(selection: FilterSelection) {
+    const matched = filterInstances(records, selection);
+    tableBody.innerHTML = '';
+
+    if (matched.length === 0) {
+      emptyMessage.removeAttribute('hidden');
+    } else {
+      emptyMessage.setAttribute('hidden', '');
+      matched
+        .sort((a, b) => a.instanceName.localeCompare(b.instanceName, 'zh-TW'))
+        .forEach((record) => {
+          tableBody.appendChild(createTableRow(record));
+        });
+    }
+  }
+
+  function applySelection(selection: FilterSelection) {
+    currentSelection = selection;
+    summaryEl.textContent = formatSummary(selection);
+    renderTable(selection);
+  }
+
+  function openModal() {
+    if (!currentSelection) {
+      return;
+    }
+
+    facilitiesForModal = getFacilities(
+      currentSelection.country,
+      currentSelection.region,
+      currentSelection.site
+    );
+
+    populateSelect(
+      modalFacilitySelect,
+      facilitiesForModal.map((facility) => ({ value: facility, label: facility }))
+    );
+    if (facilitiesForModal.length <= 1) {
+      modalFacilitySelect.disabled = true;
+    } else {
+      modalFacilitySelect.disabled = false;
+    }
+
+    populateSelect(modalSourceTypeSelect, modalTypeOptions);
+    modalSourceTypeSelect.value = currentSelection.sourceTypeId;
+
+    modalForm.reset();
+    modalFacilitySelect.value = facilitiesForModal[0] || '';
+    modalSourceTypeSelect.value = currentSelection.sourceTypeId;
+    modalError.textContent = '';
+
+    modal.setAttribute('aria-hidden', 'false');
+    modal.classList.add('is-open');
+    modal.querySelector<HTMLElement>('.modal__body input, .modal__body select, .modal__body textarea')?.focus();
+  }
+
+  function closeModal() {
+    modal.setAttribute('aria-hidden', 'true');
+    modal.classList.remove('is-open');
+    modalError.textContent = '';
+  }
+
+  countrySelect.addEventListener('change', () => {
+    updateRegions();
+    clearError();
+    clearStatus();
+  });
+
+  regionSelect.addEventListener('change', () => {
+    updateSites();
+    clearError();
+    clearStatus();
+  });
+
+  siteSelect.addEventListener('change', () => {
+    updateAddButtonState();
+    clearError();
+    clearStatus();
+  });
+
+  sourceTypeSelect.addEventListener('change', () => {
+    updateAddButtonState();
+    clearError();
+    clearStatus();
+  });
+
+  yearSelect.addEventListener('change', () => {
+    updateAddButtonState();
+    clearError();
+    clearStatus();
+  });
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    clearStatus();
+
+    if (!form.checkValidity()) {
+      form.reportValidity();
+      setError('請完整選擇篩選條件後再查詢。');
+      return;
+    }
+
+    clearError();
+
+    const selection: FilterSelection = {
+      year: yearSelect.value,
+      country: countrySelect.value,
+      region: regionSelect.value,
+      site: siteSelect.value,
+      sourceTypeId: sourceTypeSelect.value,
+    };
+
+    applySelection(selection);
+  });
+
+  addButton.addEventListener('click', () => {
+    if (!currentSelection) {
+      setError('請先查詢後再新增排放源實例。');
+      return;
+    }
+    openModal();
+  });
+
+  modalCloseButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      closeModal();
+    });
+  });
+
+  modalOverlay.addEventListener('click', () => {
+    closeModal();
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && modal.classList.contains('is-open')) {
+      closeModal();
+    }
+  });
+
+  modalForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    if (!currentSelection) {
+      return;
+    }
+
+    if (!modalForm.checkValidity()) {
+      modalForm.reportValidity();
+      modalError.textContent = '請確認所有必填欄位均已填寫。';
+      return;
+    }
+
+    const facility = modalFacilitySelect.value || facilitiesForModal[0] || currentSelection.site;
+    const sourceTypeId = modalSourceTypeSelect.value;
+    const sourceType = SOURCE_TYPES.find((type) => type.id === sourceTypeId);
+
+    const formData = new FormData(modalForm);
+
+    const instanceName = String(formData.get('instanceName') || '').trim();
+    const systemNumber = String(formData.get('systemNumber') || '').trim();
+    const assetNumber = String(formData.get('assetNumber') || '').trim();
+    const activationDate = String(formData.get('activationDate') || '');
+    const notes = String(formData.get('notes') || '').trim();
+    const maintainer = String(formData.get('maintainer') || '').trim();
+
+    if (!instanceName || !systemNumber || !assetNumber || !activationDate || !maintainer) {
+      modalError.textContent = '請完整填寫必填欄位。';
+      return;
+    }
+
+    const newRecord: InstanceRecord = {
+      id: `instance-${Date.now()}`,
+      year: currentSelection.year,
+      country: currentSelection.country,
+      region: currentSelection.region,
+      site: currentSelection.site,
+      facility,
+      sourceTypeId,
+      sourceTypeName: sourceType ? sourceType.name : sourceTypeId,
+      instanceName,
+      systemNumber,
+      assetNumber,
+      activationDate,
+      notes: notes || undefined,
+      maintainer,
+    };
+
+    records = [...records, newRecord];
+    applySelection(currentSelection);
+    setStatus('已新增 1 筆排放源實例。');
+    closeModal();
+  });
+}


### PR DESCRIPTION
## Summary
- implement the emission source instance management page with filter toolbar, data table, and modal form
- add a TypeScript initializer that seeds demo data, handles filtering, and creates new instances from the modal
- register the new initializer with the dashboard so the page loads scripted behaviour

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dde78fb5308320aeed996a42fbe686